### PR TITLE
refactor SDK's *Ix functions to only return a single instruction

### DIFF
--- a/scripts/v0.6/finalizeLaunch.ts
+++ b/scripts/v0.6/finalizeLaunch.ts
@@ -26,7 +26,7 @@ export const launch = async () => {
   await launchpad.closeLaunchIx({ launch }).rpc();
 
   const tx = await launchpad
-    .completeLaunchIx({
+    .completeLaunchTxBuilder({
       launch,
       // quoteMint: DEVNET_USDC,
       baseMint: mintKp,

--- a/scripts/v0.6/finalizeProposal.ts
+++ b/scripts/v0.6/finalizeProposal.ts
@@ -1,6 +1,6 @@
 import * as anchor from "@coral-xyz/anchor";
 import { FutarchyClient } from "@metadaoproject/programs/futarchy/v0.6";
-import { PublicKey, Transaction } from "@solana/web3.js";
+import { PublicKey } from "@solana/web3.js";
 import { BN } from "@coral-xyz/anchor";
 
 const provider = anchor.AnchorProvider.env();
@@ -32,17 +32,14 @@ const finalizeProposal = async () => {
     })
     .instruction();
 
-  // Create finalize instruction
-  const finalizeIx = await futarchyClient
-    .finalizeProposalIxV2({
+  const tx = await futarchyClient
+    .finalizeProposalTxBuilder({
       squadsProposal: proposal.squadsProposal,
       dao: proposal.dao,
       baseMint: dao.baseMint,
     })
-    .instruction();
-
-  // Build and send transaction
-  const tx = new Transaction().add(spotSwapIx, finalizeIx);
+    .preInstructions([spotSwapIx])
+    .transaction();
   tx.recentBlockhash = (
     await provider.connection.getLatestBlockhash()
   ).blockhash;

--- a/scripts/v0.7/completeLaunch.ts
+++ b/scripts/v0.7/completeLaunch.ts
@@ -26,7 +26,7 @@ export const completeLaunch = async () => {
   let launchAccount = await launchpad.fetchLaunch(LAUNCH_TO_COMPLETE);
 
   const tx = await launchpad
-    .completeLaunchIx({
+    .completeLaunchTxBuilder({
       launch: LAUNCH_TO_COMPLETE,
       baseMint: launchAccount.baseMint,
       launchAuthority: payer.publicKey,

--- a/sdk/src/futarchy/v0.6/FutarchyClient.ts
+++ b/sdk/src/futarchy/v0.6/FutarchyClient.ts
@@ -300,44 +300,39 @@ export class FutarchyClient {
 
     const squadsMultisig = multisig.getMultisigPda({ createKey: dao })[0];
 
-    return this.futarchy.methods
-      .launchProposal()
-      .accounts({
-        proposal,
-        dao,
-        baseVault,
-        quoteVault,
-        passBaseMint,
+    return this.futarchy.methods.launchProposal().accounts({
+      proposal,
+      dao,
+      baseVault,
+      quoteVault,
+      passBaseMint,
+      passQuoteMint,
+      failBaseMint,
+      failQuoteMint,
+      ammPassBaseVault: getAssociatedTokenAddressSync(passBaseMint, dao, true),
+      ammPassQuoteVault: getAssociatedTokenAddressSync(
         passQuoteMint,
-        failBaseMint,
+        dao,
+        true,
+      ),
+      ammFailBaseVault: getAssociatedTokenAddressSync(failBaseMint, dao, true),
+      ammFailQuoteVault: getAssociatedTokenAddressSync(
         failQuoteMint,
-        ammPassBaseVault: getAssociatedTokenAddressSync(
-          passBaseMint,
-          dao,
-          true,
-        ),
-        ammPassQuoteVault: getAssociatedTokenAddressSync(
-          passQuoteMint,
-          dao,
-          true,
-        ),
-        ammFailBaseVault: getAssociatedTokenAddressSync(
-          failBaseMint,
-          dao,
-          true,
-        ),
-        ammFailQuoteVault: getAssociatedTokenAddressSync(
-          failQuoteMint,
-          dao,
-          true,
-        ),
-        squadsMultisig,
-        squadsProposal,
-        payer: this.provider.publicKey,
-      })
-      .preInstructions([
-        ComputeBudgetProgram.setComputeUnitLimit({ units: 300_000 }),
-      ]);
+        dao,
+        true,
+      ),
+      squadsMultisig,
+      squadsProposal,
+      payer: this.provider.publicKey,
+    });
+  }
+
+  launchProposalTxBuilder(
+    args: Parameters<FutarchyClient["launchProposalIx"]>[0],
+  ) {
+    return this.launchProposalIx(args).preInstructions([
+      ComputeBudgetProgram.setComputeUnitLimit({ units: 300_000 }),
+    ]);
   }
 
   spotSwapIx({
@@ -747,7 +742,11 @@ export class FutarchyClient {
       storedProposal.dao,
       storedDao.baseMint,
       storedDao.quoteMint,
-    ).rpc();
+    )
+      .preInstructions([
+        ComputeBudgetProgram.setComputeUnitLimit({ units: 300_000 }),
+      ])
+      .rpc();
   }
 
   finalizeProposalIxV2({
@@ -770,6 +769,14 @@ export class FutarchyClient {
       baseMint,
       quoteMint,
     );
+  }
+
+  finalizeProposalTxBuilder(
+    args: Parameters<FutarchyClient["finalizeProposalIxV2"]>[0],
+  ) {
+    return this.finalizeProposalIxV2(args).preInstructions([
+      ComputeBudgetProgram.setComputeUnitLimit({ units: 300_000 }),
+    ]);
   }
 
   /**
@@ -797,59 +804,46 @@ export class FutarchyClient {
 
     const [vaultEventAuthority] = getEventAuthorityAddr(vaultProgramId);
 
-    return this.futarchy.methods
-      .finalizeProposal()
-      .accounts({
-        proposal,
-        dao,
-        squadsProposal,
-        squadsMultisig: multisigPda,
-        squadsMultisigProgram: SQUADS_PROGRAM_ID,
+    return this.futarchy.methods.finalizeProposal().accounts({
+      proposal,
+      dao,
+      squadsProposal,
+      squadsMultisig: multisigPda,
+      squadsMultisigProgram: SQUADS_PROGRAM_ID,
+      quoteVault,
+      question,
+      quoteVaultUnderlyingTokenAccount: getAssociatedTokenAddressSync(
+        usdc,
         quoteVault,
-        question,
-        quoteVaultUnderlyingTokenAccount: getAssociatedTokenAddressSync(
-          usdc,
-          quoteVault,
-          true,
-        ),
+        true,
+      ),
+      passQuoteMint,
+      failQuoteMint,
+      passBaseMint,
+      failBaseMint,
+      ammPassQuoteVault: getAssociatedTokenAddressSync(
         passQuoteMint,
+        dao,
+        true,
+      ),
+      ammFailQuoteVault: getAssociatedTokenAddressSync(
         failQuoteMint,
-        passBaseMint,
-        failBaseMint,
-        ammPassQuoteVault: getAssociatedTokenAddressSync(
-          passQuoteMint,
-          dao,
-          true,
-        ),
-        ammFailQuoteVault: getAssociatedTokenAddressSync(
-          failQuoteMint,
-          dao,
-          true,
-        ),
-        ammQuoteVault: getAssociatedTokenAddressSync(usdc, dao, true),
-        ammPassBaseVault: getAssociatedTokenAddressSync(
-          passBaseMint,
-          dao,
-          true,
-        ),
-        ammFailBaseVault: getAssociatedTokenAddressSync(
-          failBaseMint,
-          dao,
-          true,
-        ),
-        ammBaseVault: getAssociatedTokenAddressSync(daoToken, dao, true),
+        dao,
+        true,
+      ),
+      ammQuoteVault: getAssociatedTokenAddressSync(usdc, dao, true),
+      ammPassBaseVault: getAssociatedTokenAddressSync(passBaseMint, dao, true),
+      ammFailBaseVault: getAssociatedTokenAddressSync(failBaseMint, dao, true),
+      ammBaseVault: getAssociatedTokenAddressSync(daoToken, dao, true),
+      baseVault,
+      baseVaultUnderlyingTokenAccount: getAssociatedTokenAddressSync(
+        daoToken,
         baseVault,
-        baseVaultUnderlyingTokenAccount: getAssociatedTokenAddressSync(
-          daoToken,
-          baseVault,
-          true,
-        ),
-        vaultProgram: this.vaultClient.vaultProgram.programId,
-        vaultEventAuthority,
-      })
-      .preInstructions([
-        ComputeBudgetProgram.setComputeUnitLimit({ units: 300_000 }),
-      ]);
+        true,
+      ),
+      vaultProgram: this.vaultClient.vaultProgram.programId,
+      vaultEventAuthority,
+    });
   }
 
   updateDaoIx({ dao, params }: { dao: PublicKey; params: UpdateDaoParams }) {

--- a/sdk/src/launchpad/v0.6/LaunchpadClient.ts
+++ b/sdk/src/launchpad/v0.6/LaunchpadClient.ts
@@ -463,11 +463,16 @@ export class LaunchpadClient {
           dammV2EventAuthority,
         },
         // poolCreatorAuthority,
-      })
-      .preInstructions([
-        ComputeBudgetProgram.setComputeUnitLimit({ units: 850_000 }),
-        ComputeBudgetProgram.requestHeapFrame({ bytes: 255 * 1024 }),
-      ]);
+      });
+  }
+
+  completeLaunchTxBuilder(
+    args: Parameters<LaunchpadClient["completeLaunchIx"]>[0],
+  ) {
+    return this.completeLaunchIx(args).preInstructions([
+      ComputeBudgetProgram.setComputeUnitLimit({ units: 850_000 }),
+      ComputeBudgetProgram.requestHeapFrame({ bytes: 255 * 1024 }),
+    ]);
   }
 
   refundIx({

--- a/sdk/src/launchpad/v0.7/LaunchpadClient.ts
+++ b/sdk/src/launchpad/v0.7/LaunchpadClient.ts
@@ -432,72 +432,71 @@ export class LaunchpadClient {
       true,
     );
 
-    return this.launchpad.methods
-      .completeLaunch()
-      .accounts({
-        launch,
-        launchSigner,
-        launchQuoteVault,
-        launchBaseVault,
-        launchAuthority,
-        dao,
-        treasuryQuoteAccount,
+    return this.launchpad.methods.completeLaunch().accounts({
+      launch,
+      launchSigner,
+      launchQuoteVault,
+      launchBaseVault,
+      launchAuthority,
+      dao,
+      treasuryQuoteAccount,
+      quoteMint,
+      baseMint,
+      tokenMetadata,
+      daoOwnedLpPosition: ammPosition,
+      futarchyAmmQuoteVault: getAssociatedTokenAddressSync(
         quoteMint,
+        dao,
+        true,
+      ),
+      futarchyAmmBaseVault: getAssociatedTokenAddressSync(baseMint, dao, true),
+      staticAccounts: {
+        futarchyProgram: this.futarchyClient.getProgramId(),
+        tokenMetadataProgram: MPL_TOKEN_METADATA_PROGRAM_ID,
+        futarchyEventAuthority,
+        squadsProgram: SQUADS_PROGRAM_ID,
+        squadsProgramConfig: SQUADS_PROGRAM_CONFIG,
+        squadsProgramConfigTreasury: isDevnet
+          ? SQUADS_PROGRAM_CONFIG_TREASURY_DEVNET
+          : SQUADS_PROGRAM_CONFIG_TREASURY,
+        bidWallProgram: this.bidWall.programId,
+        bidWallEventAuthority: this.bidWall.getEventAuthorityAddress(),
+      },
+      squadsMultisig: multisigPda,
+      squadsMultisigVault: multisigVault,
+      spendingLimit,
+      bidWall,
+      bidWallQuoteTokenAccount,
+      feeRecipient,
+      meteoraAccounts: {
+        dammV2Program: DAMM_V2_PROGRAM_ID,
+        positionNftMint,
         baseMint,
-        tokenMetadata,
-        daoOwnedLpPosition: ammPosition,
-        futarchyAmmQuoteVault: getAssociatedTokenAddressSync(
-          quoteMint,
-          dao,
-          true,
-        ),
-        futarchyAmmBaseVault: getAssociatedTokenAddressSync(
-          baseMint,
-          dao,
-          true,
-        ),
-        staticAccounts: {
-          futarchyProgram: this.futarchyClient.getProgramId(),
-          tokenMetadataProgram: MPL_TOKEN_METADATA_PROGRAM_ID,
-          futarchyEventAuthority,
-          squadsProgram: SQUADS_PROGRAM_ID,
-          squadsProgramConfig: SQUADS_PROGRAM_CONFIG,
-          squadsProgramConfigTreasury: isDevnet
-            ? SQUADS_PROGRAM_CONFIG_TREASURY_DEVNET
-            : SQUADS_PROGRAM_CONFIG_TREASURY,
-          bidWallProgram: this.bidWall.programId,
-          bidWallEventAuthority: this.bidWall.getEventAuthorityAddress(),
-        },
-        squadsMultisig: multisigPda,
-        squadsMultisigVault: multisigVault,
-        spendingLimit,
-        bidWall,
-        bidWallQuoteTokenAccount,
-        feeRecipient,
-        meteoraAccounts: {
-          dammV2Program: DAMM_V2_PROGRAM_ID,
-          positionNftMint,
-          baseMint,
-          quoteMint,
-          config: meteoraConfig,
-          token2022Program: TOKEN_2022_PROGRAM_ID,
-          positionNftAccount,
-          pool,
-          // baseMint,
-          // quoteMint,
-          poolCreatorAuthority,
-          position,
-          tokenAVault,
-          tokenBVault,
-          poolAuthority,
-          dammV2EventAuthority,
-        },
-        // poolCreatorAuthority,
-      })
-      .preInstructions([
-        ComputeBudgetProgram.setComputeUnitLimit({ units: 800_000 }),
-        ComputeBudgetProgram.requestHeapFrame({ bytes: 255 * 1024 }),
-      ]);
+        quoteMint,
+        config: meteoraConfig,
+        token2022Program: TOKEN_2022_PROGRAM_ID,
+        positionNftAccount,
+        pool,
+        // baseMint,
+        // quoteMint,
+        poolCreatorAuthority,
+        position,
+        tokenAVault,
+        tokenBVault,
+        poolAuthority,
+        dammV2EventAuthority,
+      },
+      // poolCreatorAuthority,
+    });
+  }
+
+  completeLaunchTxBuilder(
+    args: Parameters<LaunchpadClient["completeLaunchIx"]>[0],
+  ) {
+    return this.completeLaunchIx(args).preInstructions([
+      ComputeBudgetProgram.setComputeUnitLimit({ units: 800_000 }),
+      ComputeBudgetProgram.requestHeapFrame({ bytes: 255 * 1024 }),
+    ]);
   }
 
   refundIx({

--- a/sdk/src/launchpad/v0.8/LaunchpadClient.ts
+++ b/sdk/src/launchpad/v0.8/LaunchpadClient.ts
@@ -531,70 +531,69 @@ export class LaunchpadClient {
       true,
     );
 
-    return this.launchpad.methods
-      .settleLaunch()
-      .accounts({
-        launch,
-        launchSigner,
-        launchQuoteVault,
-        launchBaseVault,
-        launchAuthority,
-        dao,
-        treasuryQuoteAccount,
+    return this.launchpad.methods.settleLaunch().accounts({
+      launch,
+      launchSigner,
+      launchQuoteVault,
+      launchBaseVault,
+      launchAuthority,
+      dao,
+      treasuryQuoteAccount,
+      quoteMint,
+      baseMint,
+      tokenMetadata,
+      payer,
+      daoOwnedLpPosition: ammPosition,
+      futarchyAmmQuoteVault: getAssociatedTokenAddressSync(
         quoteMint,
+        dao,
+        true,
+      ),
+      futarchyAmmBaseVault: getAssociatedTokenAddressSync(baseMint, dao, true),
+      staticAccounts: {
+        futarchyProgram: this.futarchyClient.getProgramId(),
+        tokenMetadataProgram: MPL_TOKEN_METADATA_PROGRAM_ID,
+        futarchyEventAuthority,
+        squadsProgram: SQUADS_PROGRAM_ID,
+        squadsProgramConfig: SQUADS_PROGRAM_CONFIG,
+        squadsProgramConfigTreasury: isDevnet
+          ? SQUADS_PROGRAM_CONFIG_TREASURY_DEVNET
+          : SQUADS_PROGRAM_CONFIG_TREASURY,
+        bidWallProgram: this.bidWall.programId,
+        bidWallEventAuthority: this.bidWall.getEventAuthorityAddress(),
+      },
+      squadsMultisig: multisigPda,
+      squadsMultisigVault: multisigVault,
+      spendingLimit,
+      bidWall,
+      bidWallQuoteTokenAccount,
+      feeRecipient,
+      meteoraAccounts: {
+        dammV2Program: DAMM_V2_PROGRAM_ID,
+        config: meteoraConfig,
+        token2022Program: TOKEN_2022_PROGRAM_ID,
+        positionNftAccount,
+        pool,
+        position,
+        positionNftMint,
         baseMint,
-        tokenMetadata,
-        payer,
-        daoOwnedLpPosition: ammPosition,
-        futarchyAmmQuoteVault: getAssociatedTokenAddressSync(
-          quoteMint,
-          dao,
-          true,
-        ),
-        futarchyAmmBaseVault: getAssociatedTokenAddressSync(
-          baseMint,
-          dao,
-          true,
-        ),
-        staticAccounts: {
-          futarchyProgram: this.futarchyClient.getProgramId(),
-          tokenMetadataProgram: MPL_TOKEN_METADATA_PROGRAM_ID,
-          futarchyEventAuthority,
-          squadsProgram: SQUADS_PROGRAM_ID,
-          squadsProgramConfig: SQUADS_PROGRAM_CONFIG,
-          squadsProgramConfigTreasury: isDevnet
-            ? SQUADS_PROGRAM_CONFIG_TREASURY_DEVNET
-            : SQUADS_PROGRAM_CONFIG_TREASURY,
-          bidWallProgram: this.bidWall.programId,
-          bidWallEventAuthority: this.bidWall.getEventAuthorityAddress(),
-        },
-        squadsMultisig: multisigPda,
-        squadsMultisigVault: multisigVault,
-        spendingLimit,
-        bidWall,
-        bidWallQuoteTokenAccount,
-        feeRecipient,
-        meteoraAccounts: {
-          dammV2Program: DAMM_V2_PROGRAM_ID,
-          config: meteoraConfig,
-          token2022Program: TOKEN_2022_PROGRAM_ID,
-          positionNftAccount,
-          pool,
-          position,
-          positionNftMint,
-          baseMint,
-          quoteMint,
-          tokenAVault,
-          tokenBVault,
-          poolCreatorAuthority,
-          poolAuthority,
-          dammV2EventAuthority,
-        },
-      })
-      .preInstructions([
-        ComputeBudgetProgram.setComputeUnitLimit({ units: 800_000 }),
-        ComputeBudgetProgram.requestHeapFrame({ bytes: 255 * 1024 }),
-      ]);
+        quoteMint,
+        tokenAVault,
+        tokenBVault,
+        poolCreatorAuthority,
+        poolAuthority,
+        dammV2EventAuthority,
+      },
+    });
+  }
+
+  settleLaunchTxBuilder(
+    args: Parameters<LaunchpadClient["settleLaunchIx"]>[0],
+  ) {
+    return this.settleLaunchIx(args).preInstructions([
+      ComputeBudgetProgram.setComputeUnitLimit({ units: 800_000 }),
+      ComputeBudgetProgram.requestHeapFrame({ bytes: 255 * 1024 }),
+    ]);
   }
 
   claimIx({
@@ -732,30 +731,33 @@ export class LaunchpadClient {
       this.performancePackageV2.programId,
     );
 
-    return this.launchpad.methods
-      .finalizeLaunch()
-      .accounts({
-        launch,
-        payer,
-        launchSigner,
-        baseMint,
-        dao,
-        squadsMultisig,
-        squadsMultisigVault,
-        performancePackageGrantee,
-        mintGovernor,
-        ppMintAuthority,
-        daoMintAuthority,
-        performancePackage,
-        squadsProgram: SQUADS_PROGRAM_ID,
-        mintGovernorProgram: this.mintGovernorClient.programId,
-        mintGovernorEventAuthority,
-        performancePackageV2Program: this.performancePackageV2.programId,
-        performancePackageV2EventAuthority,
-      })
-      .preInstructions([
-        ComputeBudgetProgram.setComputeUnitLimit({ units: 400_000 }),
-      ]);
+    return this.launchpad.methods.finalizeLaunch().accounts({
+      launch,
+      payer,
+      launchSigner,
+      baseMint,
+      dao,
+      squadsMultisig,
+      squadsMultisigVault,
+      performancePackageGrantee,
+      mintGovernor,
+      ppMintAuthority,
+      daoMintAuthority,
+      performancePackage,
+      squadsProgram: SQUADS_PROGRAM_ID,
+      mintGovernorProgram: this.mintGovernorClient.programId,
+      mintGovernorEventAuthority,
+      performancePackageV2Program: this.performancePackageV2.programId,
+      performancePackageV2EventAuthority,
+    });
+  }
+
+  finalizeLaunchTxBuilder(
+    args: Parameters<LaunchpadClient["finalizeLaunchIx"]>[0],
+  ) {
+    return this.finalizeLaunchIx(args).preInstructions([
+      ComputeBudgetProgram.setComputeUnitLimit({ units: 400_000 }),
+    ]);
   }
 
   claimAdditionalTokenAllocationIx({

--- a/tests/bidWall/unit/cancelBidWall.test.ts
+++ b/tests/bidWall/unit/cancelBidWall.test.ts
@@ -109,7 +109,7 @@ export default function suite() {
       .rpc();
 
     const completeLaunchTx = await launchpadClient
-      .completeLaunchIx({
+      .completeLaunchTxBuilder({
         launch,
         quoteMint: MAINNET_USDC,
         baseMint: META,

--- a/tests/bidWall/unit/closeBidWall.test.ts
+++ b/tests/bidWall/unit/closeBidWall.test.ts
@@ -108,7 +108,7 @@ export default function suite() {
       .rpc();
 
     const completeLaunchTx = await launchpadClient
-      .completeLaunchIx({
+      .completeLaunchTxBuilder({
         launch,
         quoteMint: MAINNET_USDC,
         baseMint: META,

--- a/tests/bidWall/unit/collectFees.test.ts
+++ b/tests/bidWall/unit/collectFees.test.ts
@@ -108,7 +108,7 @@ export default function suite() {
       .rpc();
 
     const completeLaunchTx = await launchpadClient
-      .completeLaunchIx({
+      .completeLaunchTxBuilder({
         launch,
         quoteMint: MAINNET_USDC,
         baseMint: META,

--- a/tests/bidWall/unit/initializeBidWall.test.ts
+++ b/tests/bidWall/unit/initializeBidWall.test.ts
@@ -107,7 +107,7 @@ export default function suite() {
       .rpc();
 
     const completeLaunchTx = await launchpadClient
-      .completeLaunchIx({
+      .completeLaunchTxBuilder({
         launch,
         quoteMint: MAINNET_USDC,
         baseMint: META,

--- a/tests/bidWall/unit/sellTokens.test.ts
+++ b/tests/bidWall/unit/sellTokens.test.ts
@@ -104,7 +104,7 @@ export default function suite() {
       .rpc();
 
     const completeLaunchTx = await launchpadClient
-      .completeLaunchIx({
+      .completeLaunchTxBuilder({
         launch,
         quoteMint: MAINNET_USDC,
         baseMint: META,

--- a/tests/futarchy/integration/futarchyAmm.test.ts
+++ b/tests/futarchy/integration/futarchyAmm.test.ts
@@ -215,7 +215,7 @@ export default function suite() {
     const proposalAccount = await this.futarchy.getProposal(proposal);
 
     await this.futarchy
-      .launchProposalIx({
+      .launchProposalTxBuilder({
         proposal,
         dao,
         baseMint: META,

--- a/tests/futarchy/unit/adminCancelProposal.test.ts
+++ b/tests/futarchy/unit/adminCancelProposal.test.ts
@@ -118,7 +118,7 @@ export default function suite() {
     proposal = await this.futarchy.initializeProposal(dao, squadsProposalPda);
 
     await this.futarchy
-      .launchProposalIx({
+      .launchProposalTxBuilder({
         proposal,
         dao,
         baseMint: META,

--- a/tests/futarchy/unit/adminRemoveProposal.test.ts
+++ b/tests/futarchy/unit/adminRemoveProposal.test.ts
@@ -227,7 +227,7 @@ export default function suite() {
 
     // Launch the proposal to move it to Pending state
     await this.futarchy
-      .launchProposalIx({
+      .launchProposalTxBuilder({
         proposal,
         dao,
         baseMint: META,

--- a/tests/futarchy/unit/collectFees.test.ts
+++ b/tests/futarchy/unit/collectFees.test.ts
@@ -239,7 +239,7 @@ export default function suite() {
       .then(callbacks[0], callbacks[1]);
 
     await this.futarchy
-      .finalizeProposalIxV2({
+      .finalizeProposalTxBuilder({
         squadsProposal,
         dao,
         baseMint: META,

--- a/tests/futarchy/unit/collectMeteoraDammFees.test.ts
+++ b/tests/futarchy/unit/collectMeteoraDammFees.test.ts
@@ -97,7 +97,7 @@ export default function suite() {
       .rpc();
 
     const completeLaunchTx = await launchpadClient
-      .completeLaunchIx({
+      .completeLaunchTxBuilder({
         launch,
         quoteMint: MAINNET_USDC,
         baseMint: META,

--- a/tests/futarchy/unit/conditionalSwap.test.ts
+++ b/tests/futarchy/unit/conditionalSwap.test.ts
@@ -1,9 +1,4 @@
-import {
-  ComputeBudgetProgram,
-  Keypair,
-  PublicKey,
-  TransactionMessage,
-} from "@solana/web3.js";
+import { Keypair, PublicKey, TransactionMessage } from "@solana/web3.js";
 import {
   createAssociatedTokenAccountIdempotentInstruction,
   getAssociatedTokenAddressSync,
@@ -258,7 +253,7 @@ export default function suite() {
 
     // Finalize the proposal first
     await this.futarchy
-      .finalizeProposalIxV2({
+      .finalizeProposalTxBuilder({
         squadsProposal,
         dao,
         baseMint: META,

--- a/tests/futarchy/unit/executeMultisigProposalApproval.test.ts
+++ b/tests/futarchy/unit/executeMultisigProposalApproval.test.ts
@@ -227,7 +227,7 @@ export default function suite() {
     // Now launch the futarchy proposal to push the AMM out of Spot.
     const storedDao = await this.futarchy.getDao(dao);
     await this.futarchy
-      .launchProposalIx({
+      .launchProposalTxBuilder({
         proposal,
         dao,
         baseMint: storedDao.baseMint,

--- a/tests/futarchy/unit/finalizeProposal.test.ts
+++ b/tests/futarchy/unit/finalizeProposal.test.ts
@@ -120,7 +120,7 @@ export default function suite() {
     proposal = await this.futarchy.initializeProposal(dao, squadsProposalPda);
 
     await this.futarchy
-      .launchProposalIx({
+      .launchProposalTxBuilder({
         proposal,
         dao,
         baseMint: META,
@@ -360,7 +360,7 @@ export default function suite() {
     );
     const storedProposalEarly = await this.futarchy.getProposal(proposal);
     await this.futarchy
-      .finalizeProposalIxV2({
+      .finalizeProposalTxBuilder({
         squadsProposal: storedProposalEarly.squadsProposal,
         dao,
         baseMint: META,
@@ -505,7 +505,7 @@ export default function suite() {
       .rpc();
 
     await this.futarchy
-      .launchProposalIx({
+      .launchProposalTxBuilder({
         proposal: teamSponsoredProposal,
         dao: daoWithTeamSponsorship,
         baseMint: META,

--- a/tests/futarchy/unit/launchProposal.test.ts
+++ b/tests/futarchy/unit/launchProposal.test.ts
@@ -205,7 +205,7 @@ export default function suite() {
 
     // Launch proposal without staking anything - should succeed because it's team-sponsored
     await this.futarchy
-      .launchProposalIx({
+      .launchProposalTxBuilder({
         proposal,
         dao,
         baseMint: META,
@@ -264,7 +264,7 @@ export default function suite() {
 
     // Launch should succeed
     await this.futarchy
-      .launchProposalIx({
+      .launchProposalTxBuilder({
         proposal,
         dao,
         baseMint: META,
@@ -321,7 +321,7 @@ export default function suite() {
 
     // Launch should succeed at exact threshold
     await this.futarchy
-      .launchProposalIx({
+      .launchProposalTxBuilder({
         proposal,
         dao,
         baseMint: META,
@@ -396,7 +396,7 @@ export default function suite() {
 
     // Launch the proposal
     await this.futarchy
-      .launchProposalIx({
+      .launchProposalTxBuilder({
         proposal,
         dao,
         baseMint: META,
@@ -457,7 +457,7 @@ export default function suite() {
     );
 
     await this.futarchy
-      .launchProposalIx({
+      .launchProposalTxBuilder({
         proposal,
         dao,
         baseMint: META,
@@ -543,7 +543,7 @@ export default function suite() {
       .rpc();
 
     await this.futarchy
-      .launchProposalIx({
+      .launchProposalTxBuilder({
         proposal,
         dao,
         baseMint: META,
@@ -647,7 +647,7 @@ export default function suite() {
     );
 
     await this.futarchy
-      .launchProposalIx({
+      .launchProposalTxBuilder({
         proposal,
         dao,
         baseMint: META,

--- a/tests/futarchy/unit/unstakeFromProposal.test.ts
+++ b/tests/futarchy/unit/unstakeFromProposal.test.ts
@@ -166,7 +166,7 @@ export default function suite() {
       .rpc();
 
     await this.futarchy
-      .launchProposalIx({
+      .launchProposalTxBuilder({
         proposal,
         dao,
         baseMint: META,
@@ -211,7 +211,7 @@ export default function suite() {
       .rpc();
 
     await this.futarchy
-      .launchProposalIx({
+      .launchProposalTxBuilder({
         proposal,
         dao,
         baseMint: META,

--- a/tests/futarchy/unit/updateDao.test.ts
+++ b/tests/futarchy/unit/updateDao.test.ts
@@ -192,7 +192,7 @@ export default function suite() {
 
     // Launch proposal A to put DAO in Futarchy state
     await this.futarchy
-      .launchProposalIx({
+      .launchProposalTxBuilder({
         proposal: proposalA,
         dao,
         baseMint: META,
@@ -346,7 +346,7 @@ export default function suite() {
 
     // Launch proposal B to put DAO in Futarchy state
     await this.futarchy
-      .launchProposalIx({
+      .launchProposalTxBuilder({
         proposal: proposalB,
         dao,
         baseMint: META,
@@ -493,7 +493,7 @@ export default function suite() {
 
     // Launch proposal A to put DAO in Futarchy state
     await this.futarchy
-      .launchProposalIx({
+      .launchProposalTxBuilder({
         proposal: proposalA,
         dao,
         baseMint: META,

--- a/tests/integration/fullLaunch.test.ts
+++ b/tests/integration/fullLaunch.test.ts
@@ -205,7 +205,7 @@ export default async function suite() {
     await this.launchpad_v6.closeLaunchIx({ launch }).rpc();
 
     const completeLaunchTx = await this.launchpad_v6
-      .completeLaunchIx({
+      .completeLaunchTxBuilder({
         launch,
         baseMint: META,
         finalRaiseAmount: new BN(500_000 * 1e6),
@@ -462,7 +462,7 @@ export default async function suite() {
 
     // Launch the proposal first
     await this.futarchy
-      .launchProposalIx({
+      .launchProposalTxBuilder({
         proposal,
         dao,
         baseMint: META,

--- a/tests/integration/fullLaunch_v7.test.ts
+++ b/tests/integration/fullLaunch_v7.test.ts
@@ -241,7 +241,7 @@ export default async function suite() {
       .rpc();
 
     const completeLaunchTx = await this.launchpad_v7
-      .completeLaunchIx({
+      .completeLaunchTxBuilder({
         launch,
         baseMint: META,
         launchAuthority: launchAuthority.publicKey,
@@ -507,7 +507,7 @@ export default async function suite() {
 
     // Launch the proposal first
     await this.futarchy
-      .launchProposalIx({
+      .launchProposalTxBuilder({
         proposal,
         dao,
         baseMint: META,

--- a/tests/integration/launchpad_v8_full_lifecycle.test.ts
+++ b/tests/integration/launchpad_v8_full_lifecycle.test.ts
@@ -251,7 +251,7 @@ export default async function suite() {
     // 6. settle_launch → verify minting, DAO creation
     // =====================
     const settleTx = await launchpadClient
-      .settleLaunchIx({
+      .settleLaunchTxBuilder({
         launch,
         baseMint: META,
         launchAuthority: launchAuthority.publicKey,
@@ -299,7 +299,7 @@ export default async function suite() {
     assert.equal(launchAccount.isFinalized, false);
 
     await launchpadClient
-      .finalizeLaunchIx({
+      .finalizeLaunchTxBuilder({
         launch,
         baseMint: META,
         performancePackageGrantee: launchAccount.performancePackageGrantee,

--- a/tests/integration/launchpad_v8_tranche_lifecycle.test.ts
+++ b/tests/integration/launchpad_v8_tranche_lifecycle.test.ts
@@ -197,7 +197,7 @@ export default async function suite() {
       .rpc();
 
     const settleTx = await launchpadClient
-      .settleLaunchIx({
+      .settleLaunchTxBuilder({
         launch,
         baseMint: META,
         launchAuthority: launchAuthority.publicKey,
@@ -222,7 +222,7 @@ export default async function suite() {
     const dao = launchAccount.dao!;
 
     await launchpadClient
-      .finalizeLaunchIx({
+      .finalizeLaunchTxBuilder({
         launch,
         baseMint: META,
         performancePackageGrantee: launchAccount.performancePackageGrantee,

--- a/tests/launchpad/unit/claim.test.ts
+++ b/tests/launchpad/unit/claim.test.ts
@@ -77,7 +77,7 @@ export default function suite() {
     await this.advanceBySeconds(60 * 60 * 24 * 7 + 100);
     await launchpadClient.closeLaunchIx({ launch }).rpc();
     const completeLaunchTx = await launchpadClient
-      .completeLaunchIx({
+      .completeLaunchTxBuilder({
         launch,
         quoteMint: MAINNET_USDC,
         baseMint: META,

--- a/tests/launchpad/unit/completeLaunch.test.ts
+++ b/tests/launchpad/unit/completeLaunch.test.ts
@@ -107,7 +107,7 @@ export default function suite() {
     await launchpadClient.closeLaunchIx({ launch }).rpc();
 
     const completeLaunchTx = await launchpadClient
-      .completeLaunchIx({
+      .completeLaunchTxBuilder({
         launch,
         quoteMint: MAINNET_USDC,
         baseMint: META,
@@ -231,7 +231,7 @@ export default function suite() {
     await launchpadClient.closeLaunchIx({ launch }).rpc();
 
     const completeLaunchTx = await launchpadClient
-      .completeLaunchIx({
+      .completeLaunchTxBuilder({
         launch,
         quoteMint: MAINNET_USDC,
         baseMint: META,
@@ -365,7 +365,7 @@ export default function suite() {
     await launchpadClient.closeLaunchIx({ launch }).rpc();
     // Try to complete again
     const completeLaunchTx = await launchpadClient
-      .completeLaunchIx({
+      .completeLaunchTxBuilder({
         launch,
         quoteMint: MAINNET_USDC,
         baseMint: META,

--- a/tests/launchpad/unit/refund.test.ts
+++ b/tests/launchpad/unit/refund.test.ts
@@ -114,7 +114,7 @@ export default function suite() {
     await launchpadClient.closeLaunchIx({ launch }).rpc();
 
     const completeLaunchTx = await launchpadClient
-      .completeLaunchIx({
+      .completeLaunchTxBuilder({
         launch,
         baseMint: META,
         finalRaiseAmount: new BN(150_000 * 1e6),
@@ -192,7 +192,7 @@ export default function suite() {
     await launchpadClient.closeLaunchIx({ launch }).rpc();
 
     const completeLaunchTx = await launchpadClient
-      .completeLaunchIx({
+      .completeLaunchTxBuilder({
         launch,
         baseMint: META,
         finalRaiseAmount: new BN(100_000 * 1e6),

--- a/tests/launchpad_v7/unit/claim.test.ts
+++ b/tests/launchpad_v7/unit/claim.test.ts
@@ -94,7 +94,7 @@ export default function suite() {
       .rpc();
 
     const completeLaunchTx = await launchpadClient
-      .completeLaunchIx({
+      .completeLaunchTxBuilder({
         launch,
         quoteMint: MAINNET_USDC,
         baseMint: META,

--- a/tests/launchpad_v7/unit/claimAdditionalTokenAllocation.test.ts
+++ b/tests/launchpad_v7/unit/claimAdditionalTokenAllocation.test.ts
@@ -110,7 +110,7 @@ export default function suite() {
       .rpc();
 
     const completeLaunchTx = await launchpadClient
-      .completeLaunchIx({
+      .completeLaunchTxBuilder({
         launch,
         quoteMint: MAINNET_USDC,
         baseMint: META,
@@ -228,7 +228,7 @@ export default function suite() {
       .rpc();
 
     const completeLaunchTx = await launchpadClient
-      .completeLaunchIx({
+      .completeLaunchTxBuilder({
         launch,
         quoteMint: MAINNET_USDC,
         baseMint: META,

--- a/tests/launchpad_v7/unit/completeLaunch.test.ts
+++ b/tests/launchpad_v7/unit/completeLaunch.test.ts
@@ -120,7 +120,7 @@ export default function suite() {
       .rpc();
 
     const completeLaunchTx = await launchpadClient
-      .completeLaunchIx({
+      .completeLaunchTxBuilder({
         launch,
         quoteMint: MAINNET_USDC,
         baseMint: META,
@@ -259,7 +259,7 @@ export default function suite() {
       .rpc();
 
     const completeLaunchTx = await launchpadClient
-      .completeLaunchIx({
+      .completeLaunchTxBuilder({
         launch,
         quoteMint: MAINNET_USDC,
         baseMint: META,
@@ -319,7 +319,7 @@ export default function suite() {
       .rpc();
 
     const completeLaunchTx = await launchpadClient
-      .completeLaunchIx({
+      .completeLaunchTxBuilder({
         launch,
         quoteMint: MAINNET_USDC,
         baseMint: META,
@@ -425,7 +425,7 @@ export default function suite() {
       .rpc();
 
     const completeLaunchTx = await launchpadClient
-      .completeLaunchIx({
+      .completeLaunchTxBuilder({
         launch,
         quoteMint: MAINNET_USDC,
         baseMint: META,
@@ -537,7 +537,7 @@ export default function suite() {
       .rpc();
 
     const completeLaunchTx = await launchpadClient
-      .completeLaunchIx({
+      .completeLaunchTxBuilder({
         launch,
         quoteMint: MAINNET_USDC,
         baseMint: META,
@@ -641,7 +641,7 @@ export default function suite() {
       .rpc();
 
     const completeLaunchTx = await launchpadClient
-      .completeLaunchIx({
+      .completeLaunchTxBuilder({
         launch,
         quoteMint: MAINNET_USDC,
         baseMint: META,
@@ -700,7 +700,7 @@ export default function suite() {
     await launchpadClient.closeLaunchIx({ launch }).rpc();
     // Try to complete again
     const completeLaunchTx = await launchpadClient
-      .completeLaunchIx({
+      .completeLaunchTxBuilder({
         launch,
         quoteMint: MAINNET_USDC,
         baseMint: META,

--- a/tests/launchpad_v7/unit/initializePerformancePackage.test.ts
+++ b/tests/launchpad_v7/unit/initializePerformancePackage.test.ts
@@ -105,7 +105,7 @@ export default function suite() {
   it("initializes performance package successfully after launch is complete", async function () {
     // Complete launch
     const completeLaunchTx = await launchpadClient
-      .completeLaunchIx({
+      .completeLaunchTxBuilder({
         launch,
         quoteMint: MAINNET_USDC,
         baseMint: META,
@@ -221,7 +221,7 @@ export default function suite() {
   it("can initialize a performance package only once", async function () {
     // Complete launch
     const completeLaunchTx = await launchpadClient
-      .completeLaunchIx({
+      .completeLaunchTxBuilder({
         launch,
         quoteMint: MAINNET_USDC,
         baseMint: META,

--- a/tests/launchpad_v7/unit/refund.test.ts
+++ b/tests/launchpad_v7/unit/refund.test.ts
@@ -134,7 +134,7 @@ export default function suite() {
       .rpc();
 
     const completeLaunchTx = await launchpadClient
-      .completeLaunchIx({
+      .completeLaunchTxBuilder({
         launch,
         baseMint: META,
         launchAuthority: launchAuthority.publicKey,

--- a/tests/launchpad_v7/unit/setFundingRecordApproval.test.ts
+++ b/tests/launchpad_v7/unit/setFundingRecordApproval.test.ts
@@ -386,7 +386,7 @@ export default function suite() {
 
     // Complete the launch
     const completeLaunchTx = await this.launchpad_v7
-      .completeLaunchIx({
+      .completeLaunchTxBuilder({
         launch,
         baseMint: META,
         launchAuthority: launchAuthority.publicKey,

--- a/tests/launchpad_v8/unit/claim.test.ts
+++ b/tests/launchpad_v8/unit/claim.test.ts
@@ -37,7 +37,7 @@ export default function suite() {
     additionalSigners: Keypair[] = [],
   ) {
     const settleTx = await client
-      .settleLaunchIx({
+      .settleLaunchTxBuilder({
         launch: params.launch,
         baseMint: params.baseMint,
         launchAuthority: params.launchAuthority,

--- a/tests/launchpad_v8/unit/claimAdditionalTokenAllocation.test.ts
+++ b/tests/launchpad_v8/unit/claimAdditionalTokenAllocation.test.ts
@@ -36,7 +36,7 @@ export default function suite() {
     additionalSigners: Keypair[] = [],
   ) {
     const settleTx = await client
-      .settleLaunchIx({
+      .settleLaunchTxBuilder({
         launch: params.launch,
         baseMint: params.baseMint,
         launchAuthority: params.launchAuthority,

--- a/tests/launchpad_v8/unit/finalizeLaunch.test.ts
+++ b/tests/launchpad_v8/unit/finalizeLaunch.test.ts
@@ -36,7 +36,7 @@ export default function suite() {
     additionalSigners: Keypair[] = [],
   ) {
     const settleTx = await client
-      .settleLaunchIx({
+      .settleLaunchTxBuilder({
         launch: params.launch,
         baseMint: params.baseMint,
         launchAuthority: params.launchAuthority,
@@ -150,7 +150,7 @@ export default function suite() {
 
     // Finalize
     await launchpadClient
-      .finalizeLaunchIx({
+      .finalizeLaunchTxBuilder({
         launch,
         baseMint: META,
         performancePackageGrantee: launchAccount.performancePackageGrantee,
@@ -236,7 +236,7 @@ export default function suite() {
     // The DAO constraint fires before validate() since launch.dao is None
     try {
       await launchpadClient
-        .finalizeLaunchIx({
+        .finalizeLaunchTxBuilder({
           launch,
           baseMint: META,
           performancePackageGrantee: this.payer.publicKey,
@@ -262,7 +262,7 @@ export default function suite() {
 
     // First finalize succeeds
     await launchpadClient
-      .finalizeLaunchIx({
+      .finalizeLaunchTxBuilder({
         launch,
         baseMint: META,
         performancePackageGrantee: launchAccount.performancePackageGrantee,
@@ -272,7 +272,7 @@ export default function suite() {
     // Second finalize fails
     try {
       await launchpadClient
-        .finalizeLaunchIx({
+        .finalizeLaunchTxBuilder({
           launch,
           baseMint: META,
           performancePackageGrantee: launchAccount.performancePackageGrantee,

--- a/tests/launchpad_v8/unit/refund.test.ts
+++ b/tests/launchpad_v8/unit/refund.test.ts
@@ -38,7 +38,7 @@ export default function suite() {
     additionalSigners: Keypair[] = [],
   ) {
     const settleTx = await client
-      .settleLaunchIx({
+      .settleLaunchTxBuilder({
         launch: params.launch,
         baseMint: params.baseMint,
         launchAuthority: params.launchAuthority,

--- a/tests/launchpad_v8/unit/setFundingRecordApproval.test.ts
+++ b/tests/launchpad_v8/unit/setFundingRecordApproval.test.ts
@@ -343,7 +343,7 @@ export default function suite() {
 
     // Settle launch to reach Complete state
     const settleTx = await launchpadClient
-      .settleLaunchIx({
+      .settleLaunchTxBuilder({
         launch,
         baseMint: META,
         launchAuthority: launchAuthority.publicKey,

--- a/tests/launchpad_v8/unit/settleLaunch.test.ts
+++ b/tests/launchpad_v8/unit/settleLaunch.test.ts
@@ -3,7 +3,6 @@ import {
   PublicKey,
   TransactionMessage,
   VersionedTransaction,
-  ComputeBudgetProgram,
 } from "@solana/web3.js";
 import { assert } from "chai";
 import { getMetadataAddr, MAINNET_USDC } from "@metadaoproject/programs";
@@ -48,7 +47,7 @@ export default function suite() {
     additionalSigners: Keypair[] = [],
   ) {
     const settleTx = await client
-      .settleLaunchIx({
+      .settleLaunchTxBuilder({
         launch: params.launch,
         baseMint: params.baseMint,
         launchAuthority: params.launchAuthority,
@@ -80,7 +79,7 @@ export default function suite() {
     additionalSigners: Keypair[] = [],
   ) {
     const settleTx = await client
-      .settleLaunchIx({
+      .settleLaunchTxBuilder({
         launch: params.launch,
         baseMint: params.baseMint,
         launchAuthority: params.launchAuthority,

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -70,6 +70,11 @@ import { toWeb3JsPublicKey } from "@metaplex-foundation/umi-web3js-adapters";
 import * as fs from "fs";
 import { AccountInfo } from "@solana/web3.js";
 
+// Incrementing CU limit so otherwise-identical helper transactions (e.g.
+// repeated mintTo calls with the same mint/amount) get unique signatures and
+// bankrun doesn't reject them as "transaction already processed".
+let mintToCuNonce = 200_000;
+
 const MPL_TOKEN_METADATA_PROGRAM_ID = toWeb3JsPublicKey(
   UMI_MPL_TOKEN_METADATA_PROGRAM_ID,
 );
@@ -381,6 +386,12 @@ before(async function () {
 
     const tx = new Transaction();
 
+    // Unique CU limit per call so two mintTo txs with identical args don't
+    // collide on signature ("transaction already processed").
+    tx.add(
+      ComputeBudgetProgram.setComputeUnitLimit({ units: mintToCuNonce++ }),
+    );
+
     tx.add(
       token.createAssociatedTokenAccountIdempotentInstruction(
         this.payer.publicKey,
@@ -650,7 +661,7 @@ before(async function () {
       await this.initializeProposal({ dao, instructions });
     const storedDao = await this.futarchy.getDao(dao);
     await this.futarchy
-      .launchProposalIx({
+      .launchProposalTxBuilder({
         proposal,
         dao,
         baseMint: storedDao.baseMint,

--- a/tests/performancePackageV2/unit/completeUnlock.test.ts
+++ b/tests/performancePackageV2/unit/completeUnlock.test.ts
@@ -822,6 +822,9 @@ export default function suite() {
         recipient: recipient.publicKey,
         signer: authority.publicKey,
       })
+      .preInstructions([
+        ComputeBudgetProgram.setComputeUnitLimit({ units: 200_001 }),
+      ])
       .signers([authority])
       .rpc();
 


### PR DESCRIPTION
...and add a *TxBuilder for functions producing those instructions, which covers additional instructions necessary for the successful execution of a transaction with said instructions.

TODO:
- [ ] Deploy prerelease of SDK (breaking changes)