### PR TITLE
Add composable dao action scripts for the admin approval flow

### DIFF
--- a/scripts/utils/adminApproval.ts
+++ b/scripts/utils/adminApproval.ts
@@ -1,0 +1,185 @@
+import { AnchorProvider } from "@coral-xyz/anchor";
+import * as multisig from "@sqds/multisig";
+import BN from "bn.js";
+import {
+  PublicKey,
+  Transaction,
+  TransactionInstruction,
+  TransactionMessage,
+} from "@solana/web3.js";
+import { FutarchyClient } from "@metadaoproject/programs/futarchy/v0.6";
+import { METADAO_MULTISIG_VAULT } from "@metadaoproject/programs";
+import {
+  createSquadsVaultTxAndProposal,
+  getSquadsPdasFromDao,
+} from "./squads.js";
+
+// MetaDAO operational multisig - its vault 0 (METADAO_MULTISIG_VAULT) is the futarchy admin
+export const METADAO_MULTISIG = new PublicKey(
+  "8N3Tvc6B1wEVKVC6iD4s6eyaCNqX2ovj2xze2q3Q9DWH",
+);
+
+const SEED_ENQUEUED_APPROVAL = Buffer.from("enqueued_approval");
+
+/**
+ * Routes a set of instructions the DAO's squads vault should execute through
+ * the admin approval system, by building two transactions:
+ *
+ * 1. `daoTransaction` creates the squads vault transaction + proposal holding
+ *    `instructions` on the DAO's multisig. Sign with the payer and
+ *    PERMISSIONLESS_ACCOUNT (the creator).
+ * 2. `metadaoTransaction` creates the squads vault transaction + proposal on
+ *    the MetaDAO operational multisig that enqueues the futarchy admin
+ *    approval of the DAO proposal. Sign with the payer, which MUST be a
+ *    member of the operational multisig with permission to propose
+ *    transactions.
+ *
+ * Once the operational multisig approves + executes its transaction, the DAO
+ * proposal can be approved + executed permissionlessly via
+ * executeMultisigProposalApproval.
+ */
+export const buildAdminApprovalTransactions = async ({
+  provider,
+  futarchy,
+  dao,
+  instructions,
+  payer,
+}: {
+  provider: AnchorProvider;
+  futarchy: FutarchyClient;
+  dao: PublicKey;
+  instructions: TransactionInstruction[];
+  payer: PublicKey;
+}) => {
+  const { multisigPda: daoMultisig, vaultPda: daoMultisigVault } =
+    await getSquadsPdasFromDao(dao);
+
+  // === DAO multisig: vault transaction with the DAO's instructions ===
+
+  const daoMultisigAccount =
+    await multisig.accounts.Multisig.fromAccountAddress(
+      provider.connection,
+      daoMultisig,
+    );
+
+  const daoTransactionIndex =
+    BigInt(daoMultisigAccount.transactionIndex.toString()) + 1n;
+
+  const daoMessage = new TransactionMessage({
+    payerKey: daoMultisigVault,
+    recentBlockhash: (await provider.connection.getLatestBlockhash()).blockhash,
+    instructions,
+  });
+
+  const {
+    vaultTxCreateIx: daoVaultTxCreateIx,
+    proposalCreateIx: daoProposalCreateIx,
+  } = await createSquadsVaultTxAndProposal(
+    daoMultisig,
+    daoTransactionIndex,
+    daoMessage,
+    payer,
+  );
+
+  const [daoVaultTransactionPda] = multisig.getTransactionPda({
+    multisigPda: daoMultisig,
+    index: daoTransactionIndex,
+  });
+
+  const [daoProposalPda] = multisig.getProposalPda({
+    multisigPda: daoMultisig,
+    transactionIndex: daoTransactionIndex,
+  });
+
+  const daoTransaction = new Transaction().add(
+    daoVaultTxCreateIx,
+    daoProposalCreateIx,
+  );
+  daoTransaction.recentBlockhash = (
+    await provider.connection.getLatestBlockhash()
+  ).blockhash;
+  daoTransaction.feePayer = payer;
+
+  // === Ops multisig: vault transaction enqueueing the admin approval ===
+
+  const metadaoMultisigAccount =
+    await multisig.accounts.Multisig.fromAccountAddress(
+      provider.connection,
+      METADAO_MULTISIG,
+    );
+
+  const metadaoTransactionIndex =
+    BigInt(metadaoMultisigAccount.transactionIndex.toString()) + 1n;
+
+  const [enqueuedApprovalPda] = PublicKey.findProgramAddressSync(
+    [
+      SEED_ENQUEUED_APPROVAL,
+      dao.toBuffer(),
+      new BN(daoTransactionIndex.toString()).toArrayLike(Buffer, "le", 8),
+    ],
+    futarchy.futarchy.programId,
+  );
+
+  // The vault signs as the futarchy admin and pays rent for the enqueued
+  // approval account, so it needs to hold a small amount of SOL
+  const enqueueApprovalIx = await futarchy.futarchy.methods
+    .adminEnqueueMultisigProposalApproval({
+      transactionIndex: new BN(daoTransactionIndex.toString()),
+    })
+    .accounts({
+      dao,
+      admin: METADAO_MULTISIG_VAULT,
+      squadsMultisig: daoMultisig,
+      squadsMultisigProposal: daoProposalPda,
+      enqueuedApproval: enqueuedApprovalPda,
+    })
+    .instruction();
+
+  const enqueueApprovalMessage = new TransactionMessage({
+    payerKey: METADAO_MULTISIG_VAULT,
+    recentBlockhash: (await provider.connection.getLatestBlockhash()).blockhash,
+    instructions: [enqueueApprovalIx],
+  });
+
+  const {
+    vaultTxCreateIx: enqueueApprovalVaultTxCreateIx,
+    proposalCreateIx: enqueueApprovalProposalCreateIx,
+  } = await createSquadsVaultTxAndProposal(
+    METADAO_MULTISIG,
+    metadaoTransactionIndex,
+    enqueueApprovalMessage,
+    payer,
+    payer,
+  );
+
+  const [metadaoVaultTransactionPda] = multisig.getTransactionPda({
+    multisigPda: METADAO_MULTISIG,
+    index: metadaoTransactionIndex,
+  });
+
+  const [metadaoProposalPda] = multisig.getProposalPda({
+    multisigPda: METADAO_MULTISIG,
+    transactionIndex: metadaoTransactionIndex,
+  });
+
+  const metadaoTransaction = new Transaction().add(
+    enqueueApprovalVaultTxCreateIx,
+    enqueueApprovalProposalCreateIx,
+  );
+  metadaoTransaction.recentBlockhash = (
+    await provider.connection.getLatestBlockhash()
+  ).blockhash;
+  metadaoTransaction.feePayer = payer;
+
+  return {
+    daoTransaction,
+    daoTransactionIndex,
+    daoVaultTransactionPda,
+    daoProposalPda,
+    metadaoTransaction,
+    metadaoTransactionIndex,
+    metadaoVaultTransactionPda,
+    metadaoProposalPda,
+    enqueuedApprovalPda,
+  };
+};

--- a/scripts/utils/adminApproval.ts
+++ b/scripts/utils/adminApproval.ts
@@ -28,11 +28,13 @@ const SEED_ENQUEUED_APPROVAL = Buffer.from("enqueued_approval");
  * 1. `daoTransaction` creates the squads vault transaction + proposal holding
  *    `instructions` on the DAO's multisig. Sign with the payer and
  *    PERMISSIONLESS_ACCOUNT (the creator).
- * 2. `metadaoTransaction` creates the squads vault transaction + proposal on
- *    the MetaDAO operational multisig that enqueues the futarchy admin
- *    approval of the DAO proposal. Sign with the payer, which MUST be a
- *    member of the operational multisig with permission to propose
- *    transactions.
+ * 2. `buildMetadaoTransaction()` builds the transaction that creates the
+ *    squads vault transaction + proposal on the MetaDAO operational multisig
+ *    enqueueing the futarchy admin approval of the DAO proposal. It reads the
+ *    operational multisig's next transaction index at call time, so call it
+ *    right before sending (after `daoTransaction` confirms). Sign with the
+ *    payer, which MUST be a member of the operational multisig with
+ *    permission to propose transactions.
  *
  * Once the operational multisig approves + executes its transaction, the DAO
  * proposal can be approved + executed permissionlessly via
@@ -102,15 +104,6 @@ export const buildAdminApprovalTransactions = async ({
 
   // === Ops multisig: vault transaction enqueueing the admin approval ===
 
-  const metadaoMultisigAccount =
-    await multisig.accounts.Multisig.fromAccountAddress(
-      provider.connection,
-      METADAO_MULTISIG,
-    );
-
-  const metadaoTransactionIndex =
-    BigInt(metadaoMultisigAccount.transactionIndex.toString()) + 1n;
-
   const [enqueuedApprovalPda] = PublicKey.findProgramAddressSync(
     [
       SEED_ENQUEUED_APPROVAL,
@@ -120,66 +113,87 @@ export const buildAdminApprovalTransactions = async ({
     futarchy.futarchy.programId,
   );
 
-  // The vault signs as the futarchy admin and pays rent for the enqueued
-  // approval account, so it needs to hold a small amount of SOL
-  const enqueueApprovalIx = await futarchy.futarchy.methods
-    .adminEnqueueMultisigProposalApproval({
-      transactionIndex: new BN(daoTransactionIndex.toString()),
-    })
-    .accounts({
-      dao,
-      admin: METADAO_MULTISIG_VAULT,
-      squadsMultisig: daoMultisig,
-      squadsMultisigProposal: daoProposalPda,
-      enqueuedApproval: enqueuedApprovalPda,
-    })
-    .instruction();
+  // Built lazily so the shared ops multisig's transaction index is read right
+  // before the transaction is sent - an index read at build time can be
+  // consumed by another operator's proposal in the meantime, which would make
+  // vaultTransactionCreate fail and leave the DAO proposal without its
+  // enqueue proposal
+  const buildMetadaoTransaction = async () => {
+    const metadaoMultisigAccount =
+      await multisig.accounts.Multisig.fromAccountAddress(
+        provider.connection,
+        METADAO_MULTISIG,
+      );
 
-  const enqueueApprovalMessage = new TransactionMessage({
-    payerKey: METADAO_MULTISIG_VAULT,
-    recentBlockhash: (await provider.connection.getLatestBlockhash()).blockhash,
-    instructions: [enqueueApprovalIx],
-  });
+    const metadaoTransactionIndex =
+      BigInt(metadaoMultisigAccount.transactionIndex.toString()) + 1n;
 
-  const {
-    vaultTxCreateIx: enqueueApprovalVaultTxCreateIx,
-    proposalCreateIx: enqueueApprovalProposalCreateIx,
-  } = await createSquadsVaultTxAndProposal(
-    METADAO_MULTISIG,
-    metadaoTransactionIndex,
-    enqueueApprovalMessage,
-    payer,
-    payer,
-  );
+    // The vault signs as the futarchy admin and pays rent for the enqueued
+    // approval account, so it needs to hold a small amount of SOL
+    const enqueueApprovalIx = await futarchy.futarchy.methods
+      .adminEnqueueMultisigProposalApproval({
+        transactionIndex: new BN(daoTransactionIndex.toString()),
+      })
+      .accounts({
+        dao,
+        admin: METADAO_MULTISIG_VAULT,
+        squadsMultisig: daoMultisig,
+        squadsMultisigProposal: daoProposalPda,
+        enqueuedApproval: enqueuedApprovalPda,
+      })
+      .instruction();
 
-  const [metadaoVaultTransactionPda] = multisig.getTransactionPda({
-    multisigPda: METADAO_MULTISIG,
-    index: metadaoTransactionIndex,
-  });
+    const enqueueApprovalMessage = new TransactionMessage({
+      payerKey: METADAO_MULTISIG_VAULT,
+      recentBlockhash: (await provider.connection.getLatestBlockhash())
+        .blockhash,
+      instructions: [enqueueApprovalIx],
+    });
 
-  const [metadaoProposalPda] = multisig.getProposalPda({
-    multisigPda: METADAO_MULTISIG,
-    transactionIndex: metadaoTransactionIndex,
-  });
+    const {
+      vaultTxCreateIx: enqueueApprovalVaultTxCreateIx,
+      proposalCreateIx: enqueueApprovalProposalCreateIx,
+    } = await createSquadsVaultTxAndProposal(
+      METADAO_MULTISIG,
+      metadaoTransactionIndex,
+      enqueueApprovalMessage,
+      payer,
+      payer,
+    );
 
-  const metadaoTransaction = new Transaction().add(
-    enqueueApprovalVaultTxCreateIx,
-    enqueueApprovalProposalCreateIx,
-  );
-  metadaoTransaction.recentBlockhash = (
-    await provider.connection.getLatestBlockhash()
-  ).blockhash;
-  metadaoTransaction.feePayer = payer;
+    const [metadaoVaultTransactionPda] = multisig.getTransactionPda({
+      multisigPda: METADAO_MULTISIG,
+      index: metadaoTransactionIndex,
+    });
+
+    const [metadaoProposalPda] = multisig.getProposalPda({
+      multisigPda: METADAO_MULTISIG,
+      transactionIndex: metadaoTransactionIndex,
+    });
+
+    const metadaoTransaction = new Transaction().add(
+      enqueueApprovalVaultTxCreateIx,
+      enqueueApprovalProposalCreateIx,
+    );
+    metadaoTransaction.recentBlockhash = (
+      await provider.connection.getLatestBlockhash()
+    ).blockhash;
+    metadaoTransaction.feePayer = payer;
+
+    return {
+      metadaoTransaction,
+      metadaoTransactionIndex,
+      metadaoVaultTransactionPda,
+      metadaoProposalPda,
+    };
+  };
 
   return {
     daoTransaction,
     daoTransactionIndex,
     daoVaultTransactionPda,
     daoProposalPda,
-    metadaoTransaction,
-    metadaoTransactionIndex,
-    metadaoVaultTransactionPda,
-    metadaoProposalPda,
     enqueuedApprovalPda,
+    buildMetadaoTransaction,
   };
 };

--- a/scripts/utils/adminApproval.ts
+++ b/scripts/utils/adminApproval.ts
@@ -23,18 +23,21 @@ const SEED_ENQUEUED_APPROVAL = Buffer.from("enqueued_approval");
 
 /**
  * Routes a set of instructions the DAO's squads vault should execute through
- * the admin approval system, by building two transactions:
+ * the admin approval system, as two lazily built transactions:
  *
- * 1. `daoTransaction` creates the squads vault transaction + proposal holding
- *    `instructions` on the DAO's multisig. Sign with the payer and
- *    PERMISSIONLESS_ACCOUNT (the creator).
- * 2. `buildMetadaoTransaction()` builds the transaction that creates the
- *    squads vault transaction + proposal on the MetaDAO operational multisig
- *    enqueueing the futarchy admin approval of the DAO proposal. It reads the
- *    operational multisig's next transaction index at call time, so call it
- *    right before sending (after `daoTransaction` confirms). Sign with the
- *    payer, which MUST be a member of the operational multisig with
- *    permission to propose transactions.
+ * 1. `buildDaoTransaction()` builds the transaction that creates the squads
+ *    vault transaction + proposal holding `instructions` on the DAO's
+ *    multisig. Sign with the payer and PERMISSIONLESS_ACCOUNT (the creator).
+ * 2. `buildMetadaoTransaction()` (returned by `buildDaoTransaction`) builds
+ *    the transaction that creates the squads vault transaction + proposal on
+ *    the MetaDAO operational multisig enqueueing the futarchy admin approval
+ *    of the DAO proposal. Sign with the payer, which MUST be a member of the
+ *    operational multisig with permission to propose transactions.
+ *
+ * Each builder reads its multisig's next transaction index at call time, so
+ * call it right before sending its transaction - an index read earlier can be
+ * consumed by someone else's proposal while previous transactions in the flow
+ * confirm, making vaultTransactionCreate fail.
  *
  * Once the operational multisig approves + executes its transaction, the DAO
  * proposal can be approved + executed permissionlessly via
@@ -56,144 +59,140 @@ export const buildAdminApprovalTransactions = async ({
   const { multisigPda: daoMultisig, vaultPda: daoMultisigVault } =
     await getSquadsPdasFromDao(dao);
 
-  // === DAO multisig: vault transaction with the DAO's instructions ===
-
-  const daoMultisigAccount =
-    await multisig.accounts.Multisig.fromAccountAddress(
-      provider.connection,
-      daoMultisig,
-    );
-
-  const daoTransactionIndex =
-    BigInt(daoMultisigAccount.transactionIndex.toString()) + 1n;
-
-  const daoMessage = new TransactionMessage({
-    payerKey: daoMultisigVault,
-    recentBlockhash: (await provider.connection.getLatestBlockhash()).blockhash,
-    instructions,
-  });
-
-  const {
-    vaultTxCreateIx: daoVaultTxCreateIx,
-    proposalCreateIx: daoProposalCreateIx,
-  } = await createSquadsVaultTxAndProposal(
-    daoMultisig,
-    daoTransactionIndex,
-    daoMessage,
-    payer,
-  );
-
-  const [daoVaultTransactionPda] = multisig.getTransactionPda({
-    multisigPda: daoMultisig,
-    index: daoTransactionIndex,
-  });
-
-  const [daoProposalPda] = multisig.getProposalPda({
-    multisigPda: daoMultisig,
-    transactionIndex: daoTransactionIndex,
-  });
-
-  const daoTransaction = new Transaction().add(
-    daoVaultTxCreateIx,
-    daoProposalCreateIx,
-  );
-  daoTransaction.recentBlockhash = (
-    await provider.connection.getLatestBlockhash()
-  ).blockhash;
-  daoTransaction.feePayer = payer;
-
-  // === Ops multisig: vault transaction enqueueing the admin approval ===
-
-  const [enqueuedApprovalPda] = PublicKey.findProgramAddressSync(
-    [
-      SEED_ENQUEUED_APPROVAL,
-      dao.toBuffer(),
-      new BN(daoTransactionIndex.toString()).toArrayLike(Buffer, "le", 8),
-    ],
-    futarchy.futarchy.programId,
-  );
-
-  // Built lazily so the shared ops multisig's transaction index is read right
-  // before the transaction is sent - an index read at build time can be
-  // consumed by another operator's proposal in the meantime, which would make
-  // vaultTransactionCreate fail and leave the DAO proposal without its
-  // enqueue proposal
-  const buildMetadaoTransaction = async () => {
-    const metadaoMultisigAccount =
+  const buildDaoTransaction = async () => {
+    const daoMultisigAccount =
       await multisig.accounts.Multisig.fromAccountAddress(
         provider.connection,
-        METADAO_MULTISIG,
+        daoMultisig,
       );
 
-    const metadaoTransactionIndex =
-      BigInt(metadaoMultisigAccount.transactionIndex.toString()) + 1n;
+    const daoTransactionIndex =
+      BigInt(daoMultisigAccount.transactionIndex.toString()) + 1n;
 
-    // The vault signs as the futarchy admin and pays rent for the enqueued
-    // approval account, so it needs to hold a small amount of SOL
-    const enqueueApprovalIx = await futarchy.futarchy.methods
-      .adminEnqueueMultisigProposalApproval({
-        transactionIndex: new BN(daoTransactionIndex.toString()),
-      })
-      .accounts({
-        dao,
-        admin: METADAO_MULTISIG_VAULT,
-        squadsMultisig: daoMultisig,
-        squadsMultisigProposal: daoProposalPda,
-        enqueuedApproval: enqueuedApprovalPda,
-      })
-      .instruction();
-
-    const enqueueApprovalMessage = new TransactionMessage({
-      payerKey: METADAO_MULTISIG_VAULT,
+    const daoMessage = new TransactionMessage({
+      payerKey: daoMultisigVault,
       recentBlockhash: (await provider.connection.getLatestBlockhash())
         .blockhash,
-      instructions: [enqueueApprovalIx],
+      instructions,
     });
 
     const {
-      vaultTxCreateIx: enqueueApprovalVaultTxCreateIx,
-      proposalCreateIx: enqueueApprovalProposalCreateIx,
+      vaultTxCreateIx: daoVaultTxCreateIx,
+      proposalCreateIx: daoProposalCreateIx,
     } = await createSquadsVaultTxAndProposal(
-      METADAO_MULTISIG,
-      metadaoTransactionIndex,
-      enqueueApprovalMessage,
-      payer,
+      daoMultisig,
+      daoTransactionIndex,
+      daoMessage,
       payer,
     );
 
-    const [metadaoVaultTransactionPda] = multisig.getTransactionPda({
-      multisigPda: METADAO_MULTISIG,
-      index: metadaoTransactionIndex,
+    const [daoVaultTransactionPda] = multisig.getTransactionPda({
+      multisigPda: daoMultisig,
+      index: daoTransactionIndex,
     });
 
-    const [metadaoProposalPda] = multisig.getProposalPda({
-      multisigPda: METADAO_MULTISIG,
-      transactionIndex: metadaoTransactionIndex,
+    const [daoProposalPda] = multisig.getProposalPda({
+      multisigPda: daoMultisig,
+      transactionIndex: daoTransactionIndex,
     });
 
-    const metadaoTransaction = new Transaction().add(
-      enqueueApprovalVaultTxCreateIx,
-      enqueueApprovalProposalCreateIx,
+    const daoTransaction = new Transaction().add(
+      daoVaultTxCreateIx,
+      daoProposalCreateIx,
     );
-    metadaoTransaction.recentBlockhash = (
+    daoTransaction.recentBlockhash = (
       await provider.connection.getLatestBlockhash()
     ).blockhash;
-    metadaoTransaction.feePayer = payer;
+    daoTransaction.feePayer = payer;
+
+    const [enqueuedApprovalPda] = PublicKey.findProgramAddressSync(
+      [
+        SEED_ENQUEUED_APPROVAL,
+        dao.toBuffer(),
+        new BN(daoTransactionIndex.toString()).toArrayLike(Buffer, "le", 8),
+      ],
+      futarchy.futarchy.programId,
+    );
+
+    const buildMetadaoTransaction = async () => {
+      const metadaoMultisigAccount =
+        await multisig.accounts.Multisig.fromAccountAddress(
+          provider.connection,
+          METADAO_MULTISIG,
+        );
+
+      const metadaoTransactionIndex =
+        BigInt(metadaoMultisigAccount.transactionIndex.toString()) + 1n;
+
+      // The vault signs as the futarchy admin and pays rent for the enqueued
+      // approval account, so it needs to hold a small amount of SOL
+      const enqueueApprovalIx = await futarchy.futarchy.methods
+        .adminEnqueueMultisigProposalApproval({
+          transactionIndex: new BN(daoTransactionIndex.toString()),
+        })
+        .accounts({
+          dao,
+          admin: METADAO_MULTISIG_VAULT,
+          squadsMultisig: daoMultisig,
+          squadsMultisigProposal: daoProposalPda,
+          enqueuedApproval: enqueuedApprovalPda,
+        })
+        .instruction();
+
+      const enqueueApprovalMessage = new TransactionMessage({
+        payerKey: METADAO_MULTISIG_VAULT,
+        recentBlockhash: (await provider.connection.getLatestBlockhash())
+          .blockhash,
+        instructions: [enqueueApprovalIx],
+      });
+
+      const {
+        vaultTxCreateIx: enqueueApprovalVaultTxCreateIx,
+        proposalCreateIx: enqueueApprovalProposalCreateIx,
+      } = await createSquadsVaultTxAndProposal(
+        METADAO_MULTISIG,
+        metadaoTransactionIndex,
+        enqueueApprovalMessage,
+        payer,
+        payer,
+      );
+
+      const [metadaoVaultTransactionPda] = multisig.getTransactionPda({
+        multisigPda: METADAO_MULTISIG,
+        index: metadaoTransactionIndex,
+      });
+
+      const [metadaoProposalPda] = multisig.getProposalPda({
+        multisigPda: METADAO_MULTISIG,
+        transactionIndex: metadaoTransactionIndex,
+      });
+
+      const metadaoTransaction = new Transaction().add(
+        enqueueApprovalVaultTxCreateIx,
+        enqueueApprovalProposalCreateIx,
+      );
+      metadaoTransaction.recentBlockhash = (
+        await provider.connection.getLatestBlockhash()
+      ).blockhash;
+      metadaoTransaction.feePayer = payer;
+
+      return {
+        metadaoTransaction,
+        metadaoTransactionIndex,
+        metadaoVaultTransactionPda,
+        metadaoProposalPda,
+      };
+    };
 
     return {
-      metadaoTransaction,
-      metadaoTransactionIndex,
-      metadaoVaultTransactionPda,
-      metadaoProposalPda,
+      daoTransaction,
+      daoTransactionIndex,
+      daoVaultTransactionPda,
+      daoProposalPda,
+      enqueuedApprovalPda,
+      buildMetadaoTransaction,
     };
   };
 
-  return {
-    daoTransaction,
-    daoTransactionIndex,
-    daoVaultTransactionPda,
-    daoProposalPda,
-    enqueuedApprovalPda,
-    buildMetadaoTransaction,
-  };
+  return { buildDaoTransaction };
 };

--- a/scripts/utils/daoActions.ts
+++ b/scripts/utils/daoActions.ts
@@ -113,6 +113,11 @@ export const withdrawLiquidity = ({
     const liquidityToWithdraw = ammPosition.liquidity
       .muln(fractionBps)
       .divn(10_000);
+    if (liquidityToWithdraw.isZero()) {
+      throw new Error(
+        `fractionBps ${fractionBps} rounds down to zero liquidity for this position`,
+      );
+    }
 
     const spotPool = daoAccount.amm.state.spot;
     if (!spotPool) {

--- a/scripts/utils/daoActions.ts
+++ b/scripts/utils/daoActions.ts
@@ -324,12 +324,36 @@ export const buildDaoActionTransactions = async ({
   };
 };
 
+// Sends a signed transaction, throwing if it isn't confirmed or lands with an
+// error
+const sendAndConfirm = async (
+  provider: AnchorProvider,
+  transaction: Transaction,
+) => {
+  const signature = await provider.connection.sendRawTransaction(
+    transaction.serialize(),
+  );
+  const status = await provider.connection.confirmTransaction(
+    signature,
+    "confirmed",
+  );
+  if (status.value.err) {
+    throw new Error(
+      `Transaction ${signature} failed: ${JSON.stringify(status.value.err)}`,
+    );
+  }
+  return signature;
+};
+
 /**
  * Signs and sends the transactions built by buildDaoActionTransactions in
  * order (setup if any, DAO multisig, ops multisig), logging the created
  * squads transactions and proposals along the way. Each squads transaction
  * is built right before it's sent, so its multisig's transaction index is
- * read as late as possible.
+ * read as late as possible, and enqueue proposal creation retries with a
+ * freshly built transaction when an attempt definitively fails (e.g. an
+ * index collision with another operator's proposal on the shared ops
+ * multisig).
  */
 export const signAndSendDaoActionTransactions = async ({
   provider,
@@ -346,10 +370,7 @@ export const signAndSendDaoActionTransactions = async ({
   if (setupTransaction) {
     setupTransaction.sign(payer);
 
-    setupSignature = await provider.connection.sendRawTransaction(
-      setupTransaction.serialize(),
-    );
-    await provider.connection.confirmTransaction(setupSignature, "confirmed");
+    setupSignature = await sendAndConfirm(provider, setupTransaction);
 
     console.log("Setup transaction sent!");
     console.log("Transaction signature:", setupSignature);
@@ -367,10 +388,7 @@ export const signAndSendDaoActionTransactions = async ({
 
   daoTransaction.sign(payer, PERMISSIONLESS_ACCOUNT);
 
-  const daoSignature = await provider.connection.sendRawTransaction(
-    daoTransaction.serialize(),
-  );
-  await provider.connection.confirmTransaction(daoSignature, "confirmed");
+  const daoSignature = await sendAndConfirm(provider, daoTransaction);
 
   console.log("DAO squads transaction created!");
   console.log("Transaction signature:", daoSignature);
@@ -378,20 +396,63 @@ export const signAndSendDaoActionTransactions = async ({
   console.log("Squads transaction:", daoVaultTransactionPda.toBase58());
   console.log("Squads proposal:", daoProposalPda.toBase58());
 
-  // Built only now so the ops multisig's transaction index is fresh
+  // The ops multisig is shared, so another operator's proposal can consume
+  // the transaction index between the build's index read and our transaction
+  // landing. A definitively failed attempt rebuilds with a fresh index and
+  // retries; an ambiguous confirmation timeout is not retried, since the
+  // transaction may still land and a second attempt would then create a
+  // duplicate enqueue proposal.
+  const sendEnqueueTransactionWithRetries = async (attempts: number) => {
+    let lastError: unknown;
+
+    for (let attempt = 1; attempt <= attempts; attempt++) {
+      const enqueue = await buildMetadaoTransaction();
+      enqueue.metadaoTransaction.sign(payer);
+
+      let signature: string;
+      try {
+        signature = await provider.connection.sendRawTransaction(
+          enqueue.metadaoTransaction.serialize(),
+        );
+      } catch (error) {
+        // Rejected at preflight, so nothing was broadcast
+        console.warn(`Enqueue attempt ${attempt} of ${attempts} rejected`);
+        lastError = error;
+        continue;
+      }
+
+      const status = await provider.connection
+        .confirmTransaction(signature, "confirmed")
+        .catch((error) => {
+          console.error(
+            `Confirmation of enqueue transaction ${signature} timed out. It may still land - check it before re-running, or a duplicate enqueue proposal could be created.`,
+          );
+          throw error;
+        });
+
+      if (status.value.err) {
+        // Landed on-chain but failed, consuming only the transaction fee
+        console.warn(
+          `Enqueue attempt ${attempt} of ${attempts} failed on-chain`,
+        );
+        lastError = new Error(
+          `Enqueue transaction ${signature} failed: ${JSON.stringify(status.value.err)}`,
+        );
+        continue;
+      }
+
+      return { ...enqueue, metadaoSignature: signature };
+    }
+
+    throw lastError;
+  };
+
   const {
-    metadaoTransaction,
     metadaoTransactionIndex,
     metadaoVaultTransactionPda,
     metadaoProposalPda,
-  } = await buildMetadaoTransaction();
-
-  metadaoTransaction.sign(payer);
-
-  const metadaoSignature = await provider.connection.sendRawTransaction(
-    metadaoTransaction.serialize(),
-  );
-  await provider.connection.confirmTransaction(metadaoSignature, "confirmed");
+    metadaoSignature,
+  } = await sendEnqueueTransactionWithRetries(3);
 
   console.log("Enqueue approval squads transaction created!");
   console.log("Transaction signature:", metadaoSignature);

--- a/scripts/utils/daoActions.ts
+++ b/scripts/utils/daoActions.ts
@@ -4,6 +4,7 @@ import {
   Keypair,
   PublicKey,
   RpcResponseAndContext,
+  SendTransactionError,
   SignatureResult,
   Transaction,
   TransactionInstruction,
@@ -100,7 +101,7 @@ export const withdrawLiquidity = ({
     );
   }
 
-  return async ({ provider, futarchy, dao, daoMultisigVault, payer }) => {
+  return async ({ futarchy, dao, daoMultisigVault, payer }) => {
     const daoAccount = await futarchy.getDao(dao);
 
     // The DAO's protocol-owned liquidity position is held by its squads vault
@@ -417,7 +418,18 @@ export const signAndSendDaoActionTransactions = async ({
           enqueue.metadaoTransaction.serialize(),
         );
       } catch (error) {
-        // Rejected at preflight, so nothing was broadcast
+        if (!(error instanceof SendTransactionError)) {
+          // Anything but the node rejecting the transaction (e.g. a
+          // transport error) is ambiguous - the transaction may have been
+          // forwarded and could still land, so retrying could create a
+          // duplicate enqueue proposal. Throw out of the retry loop instead.
+          console.error(
+            `Sending the enqueue transaction failed without a node response. It may still land - check whether proposal ${enqueue.metadaoProposalPda.toBase58()} gets created before re-running.`,
+          );
+          throw error;
+        }
+        // The node rejected the transaction at preflight, so nothing was
+        // broadcast
         console.warn(`Enqueue attempt ${attempt} of ${attempts} rejected`);
         lastError = error;
         continue;

--- a/scripts/utils/daoActions.ts
+++ b/scripts/utils/daoActions.ts
@@ -1,0 +1,374 @@
+import { AnchorProvider } from "@coral-xyz/anchor";
+import BN from "bn.js";
+import {
+  Keypair,
+  PublicKey,
+  Transaction,
+  TransactionInstruction,
+} from "@solana/web3.js";
+import { PERMISSIONLESS_ACCOUNT } from "@metadaoproject/programs";
+import {
+  createAssociatedTokenAccountIdempotentInstruction,
+  createTransferInstruction,
+  getAssociatedTokenAddressSync,
+  TOKEN_PROGRAM_ID,
+} from "@solana/spl-token";
+import {
+  FutarchyClient,
+  UpdateDaoParams,
+} from "@metadaoproject/programs/futarchy/v0.6";
+import { buildAdminApprovalTransactions } from "./adminApproval.js";
+import { getSquadsPdasFromDao } from "./squads.js";
+
+const SEED_AMM_POSITION = Buffer.from("amm_position");
+
+export type DaoActionContext = {
+  provider: AnchorProvider;
+  futarchy: FutarchyClient;
+  dao: PublicKey;
+  daoMultisig: PublicKey;
+  // The signer of the vault transaction's inner instructions
+  daoMultisigVault: PublicKey;
+  payer: PublicKey;
+};
+
+export type DaoAction = {
+  // Executed by the DAO's squads vault inside the vault transaction
+  instructions: TransactionInstruction[];
+  // Payer-funded instructions sent up front, so the vault transaction can't
+  // fail at execution time (e.g. creating token accounts)
+  setupInstructions?: TransactionInstruction[];
+};
+
+export type DaoActionBuilder = (ctx: DaoActionContext) => Promise<DaoAction>;
+
+const EMPTY_UPDATE_DAO_PARAMS: UpdateDaoParams = {
+  passThresholdBps: null,
+  secondsPerProposal: null,
+  twapInitialObservation: null,
+  twapMaxObservationChangePerUpdate: null,
+  twapStartDelaySeconds: null,
+  minQuoteFutarchicLiquidity: null,
+  minBaseFutarchicLiquidity: null,
+  baseToStake: null,
+  teamSponsoredPassThresholdBps: null,
+  teamAddress: null,
+  isOptimisticGovernanceEnabled: null,
+};
+
+// Updates the given DAO config fields, leaving the omitted ones unchanged
+export const updateDao =
+  (params: Partial<UpdateDaoParams>): DaoActionBuilder =>
+  async ({ futarchy, dao }) => ({
+    instructions: [
+      await futarchy
+        .updateDaoIx({ dao, params: { ...EMPTY_UPDATE_DAO_PARAMS, ...params } })
+        .instruction(),
+    ],
+  });
+
+// Withdraws a fraction of the vault's AMM position into the vault's token
+// accounts. The min amounts are set `slippageBps` below what the withdrawn
+// liquidity is worth right now, so reserve changes between now and execution
+// beyond that tolerance fail the withdrawal instead of silently accepting a
+// worse outcome.
+export const withdrawLiquidity =
+  ({
+    fractionBps,
+    slippageBps,
+  }: {
+    fractionBps: number;
+    slippageBps: number;
+  }): DaoActionBuilder =>
+  async ({ provider, futarchy, dao, daoMultisigVault, payer }) => {
+    const daoAccount = await futarchy.getDao(dao);
+
+    // The DAO's protocol-owned liquidity position is held by its squads vault
+    const [ammPositionPda] = PublicKey.findProgramAddressSync(
+      [SEED_AMM_POSITION, dao.toBuffer(), daoMultisigVault.toBuffer()],
+      futarchy.futarchy.programId,
+    );
+
+    const ammPosition =
+      await futarchy.futarchy.account.ammPosition.fetch(ammPositionPda);
+
+    const liquidityToWithdraw = ammPosition.liquidity
+      .muln(fractionBps)
+      .divn(10_000);
+
+    const spotPool = daoAccount.amm.state.spot;
+    if (!spotPool) {
+      throw new Error("DAO AMM is not in spot state");
+    }
+
+    // Same math as the program's get_base_and_quote_withdrawable
+    const baseWithdrawable = liquidityToWithdraw
+      .mul(spotPool.spot.baseReserves)
+      .div(daoAccount.amm.totalLiquidity);
+    const quoteWithdrawable = liquidityToWithdraw
+      .mul(spotPool.spot.quoteReserves)
+      .div(daoAccount.amm.totalLiquidity);
+
+    const minBaseAmount = baseWithdrawable
+      .muln(10_000 - slippageBps)
+      .divn(10_000);
+    const minQuoteAmount = quoteWithdrawable
+      .muln(10_000 - slippageBps)
+      .divn(10_000);
+
+    console.log("AMM position:", ammPositionPda.toBase58());
+    console.log("Position liquidity:", ammPosition.liquidity.toString());
+    console.log("Liquidity to withdraw:", liquidityToWithdraw.toString());
+    console.log("Expected base out:", baseWithdrawable.toString());
+    console.log("Expected quote out:", quoteWithdrawable.toString());
+    console.log("Min base amount:", minBaseAmount.toString());
+    console.log("Min quote amount:", minQuoteAmount.toString());
+
+    const vaultBaseTokenAccount = getAssociatedTokenAddressSync(
+      daoAccount.baseMint,
+      daoMultisigVault,
+      true,
+    );
+    const vaultQuoteTokenAccount = getAssociatedTokenAddressSync(
+      daoAccount.quoteMint,
+      daoMultisigVault,
+      true,
+    );
+
+    const withdrawLiquidityIx = await futarchy.futarchy.methods
+      .withdrawLiquidity({
+        liquidityToWithdraw,
+        minBaseAmount,
+        minQuoteAmount,
+      })
+      .accounts({
+        dao,
+        positionAuthority: daoMultisigVault,
+        liquidityProviderBaseAccount: vaultBaseTokenAccount,
+        liquidityProviderQuoteAccount: vaultQuoteTokenAccount,
+        ammBaseVault: getAssociatedTokenAddressSync(
+          daoAccount.baseMint,
+          dao,
+          true,
+        ),
+        ammQuoteVault: getAssociatedTokenAddressSync(
+          daoAccount.quoteMint,
+          dao,
+          true,
+        ),
+        ammPosition: ammPositionPda,
+        tokenProgram: TOKEN_PROGRAM_ID,
+      })
+      .instruction();
+
+    return {
+      instructions: [withdrawLiquidityIx],
+      setupInstructions: [
+        createAssociatedTokenAccountIdempotentInstruction(
+          payer,
+          vaultBaseTokenAccount,
+          daoMultisigVault,
+          daoAccount.baseMint,
+        ),
+        createAssociatedTokenAccountIdempotentInstruction(
+          payer,
+          vaultQuoteTokenAccount,
+          daoMultisigVault,
+          daoAccount.quoteMint,
+        ),
+      ],
+    };
+  };
+
+// Transfers tokens from the vault's associated token account to the recipient
+export const transferToken =
+  ({
+    mint,
+    recipient,
+    amount,
+  }: {
+    mint: PublicKey;
+    recipient: PublicKey;
+    amount: BN;
+  }): DaoActionBuilder =>
+  async ({ provider, daoMultisigVault, payer }) => {
+    const vaultTokenAccount = getAssociatedTokenAddressSync(
+      mint,
+      daoMultisigVault,
+      true,
+    );
+    const recipientTokenAccount = getAssociatedTokenAddressSync(
+      mint,
+      recipient,
+      true,
+    );
+
+    try {
+      const vaultBalance =
+        await provider.connection.getTokenAccountBalance(vaultTokenAccount);
+      console.log("Vault token balance:", vaultBalance.value.uiAmountString);
+    } catch {
+      console.warn(
+        "Vault token account not found - vault holds none of this token yet",
+      );
+    }
+
+    return {
+      instructions: [
+        createTransferInstruction(
+          vaultTokenAccount,
+          recipientTokenAccount,
+          daoMultisigVault,
+          BigInt(amount.toString()),
+        ),
+      ],
+      setupInstructions: [
+        createAssociatedTokenAccountIdempotentInstruction(
+          payer,
+          recipientTokenAccount,
+          recipient,
+          mint,
+        ),
+      ],
+    };
+  };
+
+/**
+ * Runs the action builders and routes their instructions through the admin
+ * approval system. On top of buildAdminApprovalTransactions' result, returns
+ * `setupTransaction` - a payer-funded transaction with the actions' setup
+ * instructions (null if none), to be signed by the payer and sent before the
+ * others.
+ */
+export const buildDaoActionTransactions = async ({
+  provider,
+  futarchy,
+  dao,
+  payer,
+  actions,
+}: {
+  provider: AnchorProvider;
+  futarchy: FutarchyClient;
+  dao: PublicKey;
+  payer: PublicKey;
+  actions: DaoActionBuilder[];
+}) => {
+  const { multisigPda: daoMultisig, vaultPda: daoMultisigVault } =
+    await getSquadsPdasFromDao(dao);
+
+  const ctx: DaoActionContext = {
+    provider,
+    futarchy,
+    dao,
+    daoMultisig,
+    daoMultisigVault,
+    payer,
+  };
+
+  const built: DaoAction[] = [];
+  for (const action of actions) {
+    built.push(await action(ctx));
+  }
+
+  const setupInstructions = built.flatMap(
+    (action) => action.setupInstructions ?? [],
+  );
+  const instructions = built.flatMap((action) => action.instructions);
+
+  if (instructions.length === 0) {
+    throw new Error("No instructions to enqueue - add at least one action");
+  }
+
+  let setupTransaction: Transaction | null = null;
+  if (setupInstructions.length > 0) {
+    setupTransaction = new Transaction().add(...setupInstructions);
+    setupTransaction.recentBlockhash = (
+      await provider.connection.getLatestBlockhash()
+    ).blockhash;
+    setupTransaction.feePayer = payer;
+  }
+
+  return {
+    setupTransaction,
+    ...(await buildAdminApprovalTransactions({
+      provider,
+      futarchy,
+      dao,
+      instructions,
+      payer,
+    })),
+  };
+};
+
+/**
+ * Signs and sends the transactions built by buildDaoActionTransactions in
+ * order (setup if any, DAO multisig, ops multisig), logging the created
+ * squads transactions and proposals along the way.
+ */
+export const signAndSendDaoActionTransactions = async ({
+  provider,
+  payer,
+  transactions,
+}: {
+  provider: AnchorProvider;
+  payer: Keypair;
+  transactions: Awaited<ReturnType<typeof buildDaoActionTransactions>>;
+}) => {
+  const {
+    setupTransaction,
+    daoTransaction,
+    daoTransactionIndex,
+    daoVaultTransactionPda,
+    daoProposalPda,
+    metadaoTransaction,
+    metadaoTransactionIndex,
+    metadaoVaultTransactionPda,
+    metadaoProposalPda,
+    enqueuedApprovalPda,
+  } = transactions;
+
+  let setupSignature: string | null = null;
+  if (setupTransaction) {
+    setupTransaction.sign(payer);
+
+    setupSignature = await provider.connection.sendRawTransaction(
+      setupTransaction.serialize(),
+    );
+    await provider.connection.confirmTransaction(setupSignature, "confirmed");
+
+    console.log("Setup transaction sent!");
+    console.log("Transaction signature:", setupSignature);
+  }
+
+  daoTransaction.sign(payer, PERMISSIONLESS_ACCOUNT);
+
+  const daoSignature = await provider.connection.sendRawTransaction(
+    daoTransaction.serialize(),
+  );
+  await provider.connection.confirmTransaction(daoSignature, "confirmed");
+
+  console.log("DAO squads transaction created!");
+  console.log("Transaction signature:", daoSignature);
+  console.log("Squads transaction index:", daoTransactionIndex.toString());
+  console.log("Squads transaction:", daoVaultTransactionPda.toBase58());
+  console.log("Squads proposal:", daoProposalPda.toBase58());
+
+  metadaoTransaction.sign(payer);
+
+  const metadaoSignature = await provider.connection.sendRawTransaction(
+    metadaoTransaction.serialize(),
+  );
+  await provider.connection.confirmTransaction(metadaoSignature, "confirmed");
+
+  console.log("Enqueue approval squads transaction created!");
+  console.log("Transaction signature:", metadaoSignature);
+  console.log("Squads transaction index:", metadaoTransactionIndex.toString());
+  console.log("Squads transaction:", metadaoVaultTransactionPda.toBase58());
+  console.log("Squads proposal:", metadaoProposalPda.toBase58());
+  console.log("Enqueued approval:", enqueuedApprovalPda.toBase58());
+  console.log(
+    "Go ahead and approve + execute the enqueue approval through Squads.",
+  );
+
+  return { setupSignature, daoSignature, metadaoSignature };
+};

--- a/scripts/utils/daoActions.ts
+++ b/scripts/utils/daoActions.ts
@@ -3,6 +3,8 @@ import BN from "bn.js";
 import {
   Keypair,
   PublicKey,
+  RpcResponseAndContext,
+  SignatureResult,
   Transaction,
   TransactionInstruction,
 } from "@solana/web3.js";
@@ -421,14 +423,21 @@ export const signAndSendDaoActionTransactions = async ({
         continue;
       }
 
-      const status = await provider.connection
-        .confirmTransaction(signature, "confirmed")
-        .catch((error) => {
-          console.error(
-            `Confirmation of enqueue transaction ${signature} timed out. It may still land - check it before re-running, or a duplicate enqueue proposal could be created.`,
-          );
-          throw error;
-        });
+      let status: RpcResponseAndContext<SignatureResult>;
+      try {
+        status = await provider.connection.confirmTransaction(
+          signature,
+          "confirmed",
+        );
+      } catch (error) {
+        // The timeout is ambiguous - the transaction may still land, so
+        // retrying could create a duplicate enqueue proposal. Throw out of
+        // the retry loop instead.
+        console.error(
+          `Confirmation of enqueue transaction ${signature} timed out. It may still land - check it before re-running, or a duplicate enqueue proposal could be created.`,
+        );
+        throw error;
+      }
 
       if (status.value.err) {
         // Landed on-chain but failed, consuming only the transaction fee

--- a/scripts/utils/daoActions.ts
+++ b/scripts/utils/daoActions.ts
@@ -72,15 +72,33 @@ export const updateDao =
 // liquidity is worth right now, so reserve changes between now and execution
 // beyond that tolerance fail the withdrawal instead of silently accepting a
 // worse outcome.
-export const withdrawLiquidity =
-  ({
-    fractionBps,
-    slippageBps,
-  }: {
-    fractionBps: number;
-    slippageBps: number;
-  }): DaoActionBuilder =>
-  async ({ provider, futarchy, dao, daoMultisigVault, payer }) => {
+export const withdrawLiquidity = ({
+  fractionBps,
+  slippageBps,
+}: {
+  fractionBps: number;
+  slippageBps: number;
+}): DaoActionBuilder => {
+  if (
+    !Number.isInteger(fractionBps) ||
+    fractionBps <= 0 ||
+    fractionBps > 10_000
+  ) {
+    throw new Error(
+      `fractionBps must be an integer between 1 and 10000, got ${fractionBps}`,
+    );
+  }
+  if (
+    !Number.isInteger(slippageBps) ||
+    slippageBps < 0 ||
+    slippageBps > 10_000
+  ) {
+    throw new Error(
+      `slippageBps must be an integer between 0 and 10000, got ${slippageBps}`,
+    );
+  }
+
+  return async ({ provider, futarchy, dao, daoMultisigVault, payer }) => {
     const daoAccount = await futarchy.getDao(dao);
 
     // The DAO's protocol-owned liquidity position is held by its squads vault
@@ -179,6 +197,7 @@ export const withdrawLiquidity =
       ],
     };
   };
+};
 
 // Transfers tokens from the vault's associated token account to the recipient
 export const transferToken =
@@ -303,7 +322,9 @@ export const buildDaoActionTransactions = async ({
 /**
  * Signs and sends the transactions built by buildDaoActionTransactions in
  * order (setup if any, DAO multisig, ops multisig), logging the created
- * squads transactions and proposals along the way.
+ * squads transactions and proposals along the way. The ops multisig
+ * transaction is built only after the DAO transaction confirms, so its
+ * transaction index is read as late as possible.
  */
 export const signAndSendDaoActionTransactions = async ({
   provider,
@@ -320,11 +341,8 @@ export const signAndSendDaoActionTransactions = async ({
     daoTransactionIndex,
     daoVaultTransactionPda,
     daoProposalPda,
-    metadaoTransaction,
-    metadaoTransactionIndex,
-    metadaoVaultTransactionPda,
-    metadaoProposalPda,
     enqueuedApprovalPda,
+    buildMetadaoTransaction,
   } = transactions;
 
   let setupSignature: string | null = null;
@@ -352,6 +370,14 @@ export const signAndSendDaoActionTransactions = async ({
   console.log("Squads transaction index:", daoTransactionIndex.toString());
   console.log("Squads transaction:", daoVaultTransactionPda.toBase58());
   console.log("Squads proposal:", daoProposalPda.toBase58());
+
+  // Built only now so the ops multisig's transaction index is fresh
+  const {
+    metadaoTransaction,
+    metadaoTransactionIndex,
+    metadaoVaultTransactionPda,
+    metadaoProposalPda,
+  } = await buildMetadaoTransaction();
 
   metadaoTransaction.sign(payer);
 

--- a/scripts/utils/daoActions.ts
+++ b/scripts/utils/daoActions.ts
@@ -322,9 +322,9 @@ export const buildDaoActionTransactions = async ({
 /**
  * Signs and sends the transactions built by buildDaoActionTransactions in
  * order (setup if any, DAO multisig, ops multisig), logging the created
- * squads transactions and proposals along the way. The ops multisig
- * transaction is built only after the DAO transaction confirms, so its
- * transaction index is read as late as possible.
+ * squads transactions and proposals along the way. Each squads transaction
+ * is built right before it's sent, so its multisig's transaction index is
+ * read as late as possible.
  */
 export const signAndSendDaoActionTransactions = async ({
   provider,
@@ -335,15 +335,7 @@ export const signAndSendDaoActionTransactions = async ({
   payer: Keypair;
   transactions: Awaited<ReturnType<typeof buildDaoActionTransactions>>;
 }) => {
-  const {
-    setupTransaction,
-    daoTransaction,
-    daoTransactionIndex,
-    daoVaultTransactionPda,
-    daoProposalPda,
-    enqueuedApprovalPda,
-    buildMetadaoTransaction,
-  } = transactions;
+  const { setupTransaction, buildDaoTransaction } = transactions;
 
   let setupSignature: string | null = null;
   if (setupTransaction) {
@@ -357,6 +349,16 @@ export const signAndSendDaoActionTransactions = async ({
     console.log("Setup transaction sent!");
     console.log("Transaction signature:", setupSignature);
   }
+
+  // Built only now so the DAO multisig's transaction index is fresh
+  const {
+    daoTransaction,
+    daoTransactionIndex,
+    daoVaultTransactionPda,
+    daoProposalPda,
+    enqueuedApprovalPda,
+    buildMetadaoTransaction,
+  } = await buildDaoTransaction();
 
   daoTransaction.sign(payer, PERMISSIONLESS_ACCOUNT);
 

--- a/scripts/utils/daoActions.ts
+++ b/scripts/utils/daoActions.ts
@@ -1,4 +1,5 @@
 import { AnchorProvider } from "@coral-xyz/anchor";
+import * as multisig from "@sqds/multisig";
 import BN from "bn.js";
 import {
   Keypair,
@@ -30,7 +31,8 @@ export type DaoActionContext = {
   futarchy: FutarchyClient;
   dao: PublicKey;
   daoMultisig: PublicKey;
-  // The signer of the vault transaction's inner instructions
+  // The signer of the vault transaction's inner instructions, unless an
+  // instruction is signed by the DAO itself (see removeSpendingLimit)
   daoMultisigVault: PublicKey;
   payer: PublicKey;
 };
@@ -41,6 +43,11 @@ export type DaoAction = {
   // Payer-funded instructions sent up front, so the vault transaction can't
   // fail at execution time (e.g. creating token accounts)
   setupInstructions?: TransactionInstruction[];
+  // Set when the DAO itself signs any of the instructions. Only
+  // admin_execute_multisig_proposal signs for the DAO, so the proposal has to
+  // be executed with adminExecuteMultisigProposal.ts rather than
+  // permissionlessly.
+  requiresAdminExecution?: boolean;
 };
 
 export type DaoActionBuilder = (ctx: DaoActionContext) => Promise<DaoAction>;
@@ -260,12 +267,51 @@ export const transferToken =
     };
   };
 
+// Removes the DAO's spending limit, returning its rent to the vault. The DAO
+// is its multisig's config authority, so the DAO signs this rather than the
+// vault, which makes the proposal admin-execute only.
+export const removeSpendingLimit =
+  (): DaoActionBuilder =>
+  async ({ provider, dao, daoMultisig, daoMultisigVault }) => {
+    const [spendingLimit] = multisig.getSpendingLimitPda({
+      multisigPda: daoMultisig,
+      createKey: dao,
+    });
+    const spendingLimitAccount =
+      await multisig.accounts.SpendingLimit.fromAccountAddress(
+        provider.connection,
+        spendingLimit,
+      );
+
+    console.log("Spending limit:", spendingLimit.toBase58());
+    console.log(
+      `  ${spendingLimitAccount.amount.toString()} of ${spendingLimitAccount.mint.toBase58()} per ${multisig.types.Period[spendingLimitAccount.period]}`,
+    );
+    console.log(
+      "  members:",
+      spendingLimitAccount.members.map((m) => m.toBase58()).join(", "),
+    );
+
+    return {
+      instructions: [
+        multisig.instructions.multisigRemoveSpendingLimit({
+          multisigPda: daoMultisig,
+          configAuthority: dao,
+          spendingLimit,
+          rentCollector: daoMultisigVault,
+        }),
+      ],
+      requiresAdminExecution: true,
+    };
+  };
+
 /**
  * Runs the action builders and routes their instructions through the admin
  * approval system. On top of buildAdminApprovalTransactions' result, returns
  * `setupTransaction` - a payer-funded transaction with the actions' setup
  * instructions (null if none), to be signed by the payer and sent before the
- * others.
+ * others - and `requiresAdminExecution`, set when any action needs the DAO
+ * proposal executed through admin_execute_multisig_proposal.
  */
 export const buildDaoActionTransactions = async ({
   provider,
@@ -306,6 +352,10 @@ export const buildDaoActionTransactions = async ({
     throw new Error("No instructions to enqueue - add at least one action");
   }
 
+  const requiresAdminExecution = built.some(
+    (action) => action.requiresAdminExecution,
+  );
+
   let setupTransaction: Transaction | null = null;
   if (setupInstructions.length > 0) {
     setupTransaction = new Transaction().add(...setupInstructions);
@@ -317,6 +367,7 @@ export const buildDaoActionTransactions = async ({
 
   return {
     setupTransaction,
+    requiresAdminExecution,
     ...(await buildAdminApprovalTransactions({
       provider,
       futarchy,
@@ -367,7 +418,8 @@ export const signAndSendDaoActionTransactions = async ({
   payer: Keypair;
   transactions: Awaited<ReturnType<typeof buildDaoActionTransactions>>;
 }) => {
-  const { setupTransaction, buildDaoTransaction } = transactions;
+  const { setupTransaction, requiresAdminExecution, buildDaoTransaction } =
+    transactions;
 
   let setupSignature: string | null = null;
   if (setupTransaction) {
@@ -484,6 +536,15 @@ export const signAndSendDaoActionTransactions = async ({
   console.log(
     "Go ahead and approve + execute the enqueue approval through Squads.",
   );
+  if (requiresAdminExecution) {
+    console.log(
+      "The DAO signs some of the enqueued instructions, so the permissionless execute can't run this proposal. Once the enqueue approval executes, run adminExecuteMultisigProposal.ts with the admin key.",
+    );
+  } else {
+    console.log(
+      "Then approve + execute the DAO proposal with executeMultisigProposalApproval.ts.",
+    );
+  }
 
   return { setupSignature, daoSignature, metadaoSignature };
 };

--- a/scripts/utils/squads.ts
+++ b/scripts/utils/squads.ts
@@ -38,11 +38,12 @@ export const createSquadsVaultTxAndProposal = async (
   transactionIndex: bigint,
   transactionMessage: TransactionMessage,
   payer: PublicKey,
+  creator: PublicKey = PERMISSIONLESS_ACCOUNT.publicKey,
 ) => {
   const vaultTxCreateIx = multisig.instructions.vaultTransactionCreate({
     multisigPda: squadsMultisig,
     transactionIndex: transactionIndex,
-    creator: PERMISSIONLESS_ACCOUNT.publicKey,
+    creator,
     rentPayer: payer,
     vaultIndex: 0,
     ephemeralSigners: 0,
@@ -52,7 +53,7 @@ export const createSquadsVaultTxAndProposal = async (
   const proposalCreateIx = multisig.instructions.proposalCreate({
     multisigPda: squadsMultisig,
     transactionIndex: transactionIndex,
-    creator: PERMISSIONLESS_ACCOUNT.publicKey,
+    creator,
     rentPayer: payer,
     isDraft: false,
   });

--- a/scripts/v0.6/adminExecuteMultisigProposal.ts
+++ b/scripts/v0.6/adminExecuteMultisigProposal.ts
@@ -1,0 +1,164 @@
+import * as anchor from "@coral-xyz/anchor";
+import * as multisig from "@sqds/multisig";
+import BN from "bn.js";
+import {
+  PublicKey,
+  TransactionInstruction,
+  TransactionMessage,
+  VersionedTransaction,
+} from "@solana/web3.js";
+import { FutarchyClient } from "@metadaoproject/programs/futarchy/v0.6";
+
+// Executes a DAO squads proposal through admin_execute_multisig_proposal.
+// Needed when the DAO itself signs some of the proposal's instructions (e.g.
+// removing a spending limit): futarchy signs for the DAO in the execute CPI,
+// which the permissionless squads execute can't do. If the proposal's
+// enqueued approval hasn't been executed yet, it's executed in the same
+// transaction.
+
+///////////////
+// Constants //
+///////////////
+
+// The squads proposal (on the DAO's multisig) to execute
+const SQUADS_PROPOSAL = new PublicKey("SQUADS_PROPOSAL_PUBKEY");
+
+////////////////
+// Operations //
+////////////////
+
+const SEED_ENQUEUED_APPROVAL = Buffer.from("enqueued_approval");
+
+const provider = anchor.AnchorProvider.env();
+
+// Payer MUST be the futarchy admin key
+const payer = provider.wallet["payer"];
+
+const futarchy = FutarchyClient.createClient({ provider });
+
+async function main() {
+  const proposal = await multisig.accounts.Proposal.fromAccountAddress(
+    provider.connection,
+    SQUADS_PROPOSAL,
+  );
+  const daoMultisig = proposal.multisig;
+  const transactionIndex = BigInt(proposal.transactionIndex.toString());
+
+  // The DAO is the multisig's create key
+  const daoMultisigAccount =
+    await multisig.accounts.Multisig.fromAccountAddress(
+      provider.connection,
+      daoMultisig,
+    );
+  const dao = daoMultisigAccount.createKey;
+
+  const [vaultTransactionPda] = multisig.getTransactionPda({
+    multisigPda: daoMultisig,
+    index: transactionIndex,
+  });
+  const vaultTransaction =
+    await multisig.accounts.VaultTransaction.fromAccountAddress(
+      provider.connection,
+      vaultTransactionPda,
+    );
+  const [vaultPda] = multisig.getVaultPda({
+    multisigPda: daoMultisig,
+    index: vaultTransaction.vaultIndex,
+  });
+
+  console.log("DAO:", dao.toBase58());
+  console.log("Squads transaction index:", transactionIndex.toString());
+  console.log("Squads proposal status:", proposal.status.__kind);
+
+  const instructions: TransactionInstruction[] = [];
+
+  const [enqueuedApprovalPda] = PublicKey.findProgramAddressSync(
+    [
+      SEED_ENQUEUED_APPROVAL,
+      dao.toBuffer(),
+      new BN(transactionIndex.toString()).toArrayLike(Buffer, "le", 8),
+    ],
+    futarchy.futarchy.programId,
+  );
+  const enqueuedApproval =
+    await provider.connection.getAccountInfo(enqueuedApprovalPda);
+
+  if (enqueuedApproval) {
+    console.log("Executing the pending enqueued approval first");
+    instructions.push(
+      await futarchy.futarchy.methods
+        .executeMultisigProposalApproval()
+        .accounts({
+          dao,
+          rentReceiver: payer.publicKey,
+          squadsMultisig: daoMultisig,
+          squadsMultisigProposal: SQUADS_PROPOSAL,
+          enqueuedApproval: enqueuedApprovalPda,
+          squadsMultisigProgram: multisig.PROGRAM_ID,
+        })
+        .instruction(),
+    );
+  } else if (proposal.status.__kind !== "Approved") {
+    throw new Error(
+      `Squads proposal is ${proposal.status.__kind} and has no enqueued approval - has the ops multisig executed the enqueue?`,
+    );
+  }
+
+  const { accountMetas, lookupTableAccounts } =
+    await multisig.utils.accountsForTransactionExecute({
+      connection: provider.connection,
+      message: vaultTransaction.message,
+      ephemeralSignerBumps: [...vaultTransaction.ephemeralSignerBumps],
+      vaultPda,
+      transactionPda: vaultTransactionPda,
+      programId: multisig.PROGRAM_ID,
+    });
+
+  instructions.push(
+    await futarchy.futarchy.methods
+      .adminExecuteMultisigProposal()
+      .accounts({
+        dao,
+        admin: payer.publicKey,
+        squadsMultisig: daoMultisig,
+        squadsMultisigProposal: SQUADS_PROPOSAL,
+        squadsMultisigVaultTransaction: vaultTransactionPda,
+        squadsMultisigProgram: multisig.PROGRAM_ID,
+      })
+      // The DAO can't sign the outer transaction - futarchy signs for it in
+      // the CPI - so its meta must not require a signature here
+      .remainingAccounts(
+        accountMetas.map((meta) =>
+          meta.pubkey.equals(dao) ? { ...meta, isSigner: false } : meta,
+        ),
+      )
+      .instruction(),
+  );
+
+  const message = new TransactionMessage({
+    payerKey: payer.publicKey,
+    recentBlockhash: (await provider.connection.getLatestBlockhash()).blockhash,
+    instructions,
+  }).compileToV0Message(lookupTableAccounts);
+  const transaction = new VersionedTransaction(message);
+  transaction.sign([payer]);
+
+  const signature = await provider.connection.sendTransaction(transaction);
+  const status = await provider.connection.confirmTransaction(
+    signature,
+    "confirmed",
+  );
+  if (status.value.err) {
+    throw new Error(
+      `Transaction ${signature} failed: ${JSON.stringify(status.value.err)}`,
+    );
+  }
+
+  console.log("DAO squads proposal executed!");
+  console.log("Transaction signature:", signature);
+}
+
+main().catch((error) => {
+  console.error("Error executing DAO squads proposal:", error);
+  process.exit(1);
+});

--- a/scripts/v0.6/enqueueTemplate.ts
+++ b/scripts/v0.6/enqueueTemplate.ts
@@ -5,6 +5,7 @@ import { FutarchyClient } from "@metadaoproject/programs/futarchy/v0.6";
 import { MAINNET_USDC } from "@metadaoproject/programs";
 import {
   buildDaoActionTransactions,
+  removeSpendingLimit,
   signAndSendDaoActionTransactions,
   transferToken,
   updateDao,
@@ -14,14 +15,15 @@ import {
 // Template for enqueueing DAO vault actions through the admin approval system.
 // Copy it, set the constants, and compose the actions below. Once the ops
 // multisig approves + executes the enqueue, approve + execute the DAO proposal
-// with executeMultisigProposalApproval.ts.
+// with executeMultisigProposalApproval.ts - or adminExecuteMultisigProposal.ts
+// when an action is signed by the DAO itself, like removeSpendingLimit.
 
 ///////////////
 // Constants //
 ///////////////
 
 // The DAO whose vault should execute the actions
-const DAO = new PublicKey("DAO_PUBKEY");
+const DAO = new PublicKey("3D854kknnQhu9xVaRNV154oZ9oN2WF3tXsq3LDu7fFMn");
 
 ////////////////
 // Operations //
@@ -44,7 +46,13 @@ async function main() {
     actions: [
       // Compose the actions the DAO's vault should execute, e.g.:
       //
-      // updateDao({ teamAddress: new PublicKey("...") }),
+      updateDao({
+        baseToStake: new BN(1_500_000).mul(new BN(10 ** 6)),
+        passThresholdBps: 300,
+        teamSponsoredPassThresholdBps: -300,
+        minBaseFutarchicLiquidity: new BN(1),
+        minQuoteFutarchicLiquidity: new BN(1),
+      }),
       //
       // withdrawLiquidity({ fractionBps: 5_000, slippageBps: 2_000 }),
       //
@@ -53,6 +61,8 @@ async function main() {
       //   recipient: new PublicKey("..."),
       //   amount: new BN(1_000).mul(new BN(10 ** 6)),
       // }),
+      //
+      // removeSpendingLimit(),
     ],
   });
 

--- a/scripts/v0.6/enqueueTemplate.ts
+++ b/scripts/v0.6/enqueueTemplate.ts
@@ -1,0 +1,65 @@
+import * as anchor from "@coral-xyz/anchor";
+import BN from "bn.js";
+import { PublicKey } from "@solana/web3.js";
+import { FutarchyClient } from "@metadaoproject/programs/futarchy/v0.6";
+import { MAINNET_USDC } from "@metadaoproject/programs";
+import {
+  buildDaoActionTransactions,
+  signAndSendDaoActionTransactions,
+  transferToken,
+  updateDao,
+  withdrawLiquidity,
+} from "../utils/daoActions.js";
+
+// Template for enqueueing DAO vault actions through the admin approval system.
+// Copy it, set the constants, and compose the actions below. Once the ops
+// multisig approves + executes the enqueue, approve + execute the DAO proposal
+// with executeMultisigProposalApproval.ts.
+
+///////////////
+// Constants //
+///////////////
+
+// The DAO whose vault should execute the actions
+const DAO = new PublicKey("DAO_PUBKEY");
+
+////////////////
+// Operations //
+////////////////
+
+const provider = anchor.AnchorProvider.env();
+
+// Payer MUST be a member of the MetaDAO operational multisig with permission
+// to propose transactions
+const payer = provider.wallet["payer"];
+
+const futarchy = FutarchyClient.createClient({ provider });
+
+async function main() {
+  const transactions = await buildDaoActionTransactions({
+    provider,
+    futarchy,
+    dao: DAO,
+    payer: payer.publicKey,
+    actions: [
+      // Compose the actions the DAO's vault should execute, e.g.:
+      //
+      // updateDao({ teamAddress: new PublicKey("...") }),
+      //
+      // withdrawLiquidity({ fractionBps: 5_000, slippageBps: 2_000 }),
+      //
+      // transferToken({
+      //   mint: MAINNET_USDC,
+      //   recipient: new PublicKey("..."),
+      //   amount: new BN(1_000).mul(new BN(10 ** 6)),
+      // }),
+    ],
+  });
+
+  await signAndSendDaoActionTransactions({ provider, payer, transactions });
+}
+
+main().catch((error) => {
+  console.error("Error enqueueing DAO actions:", error);
+  process.exit(1);
+});

--- a/scripts/v0.6/enqueueTemplate.ts
+++ b/scripts/v0.6/enqueueTemplate.ts
@@ -23,7 +23,7 @@ import {
 ///////////////
 
 // The DAO whose vault should execute the actions
-const DAO = new PublicKey("3D854kknnQhu9xVaRNV154oZ9oN2WF3tXsq3LDu7fFMn");
+const DAO = new PublicKey("DAO_ADDRESS");
 
 ////////////////
 // Operations //


### PR DESCRIPTION
Adds reusable script utilities for routing DAO vault actions through the futarchy admin approval system, so one-off operational scripts can be composed from small building blocks instead of hand-rolling the Squads plumbing each time.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds composable utilities for routing DAO vault actions through futarchy admin approval.
- Introduces lazy DAO and operational multisig transaction builders that obtain transaction indexes immediately before submission.
- Adds reusable DAO actions for parameter updates, liquidity withdrawals, and token transfers.
- Adds guarded operational-proposal retries while aborting on ambiguous send or confirmation failures.
- Adds an example script for composing and submitting DAO actions.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| scripts/utils/adminApproval.ts | Adds lazy builders for DAO and operational Squads proposals, addressing the previously reported stale-index windows. |
| scripts/utils/daoActions.ts | Adds validated action builders and sequential submission logic that avoids retrying ambiguous enqueue outcomes. |
| scripts/utils/squads.ts | Allows callers to select the Squads transaction creator while preserving the permissionless account as the default. |
| scripts/v0.6/enqueueTemplate.ts | Adds a template demonstrating how to compose and submit admin-approved DAO actions. |

</details>

<sub>Reviews (7): Last reviewed commit: ["include any ambiguous sends to failure r..."](https://github.com/metadaoproject/programs/commit/c19dda053d3a1db1c188c8858256abe96ef23815) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49057705)</sub>

<!-- /greptile_comment -->