### PR TITLE
Add script for team sponsorship via squads import

### DIFF
--- a/Anchor.toml
+++ b/Anchor.toml
@@ -57,6 +57,7 @@ v06-collect-meteora-damm-fees = "yarn run tsx scripts/v0.6/collectMeteoraDammFee
 v06-return-funds = "yarn run tsx scripts/v0.6/returnFunds.ts"
 v06-dump-daos = "yarn run tsx scripts/v0.6/dumpDaos.ts"
 v06-migrate-daos = "yarn run tsx scripts/v0.6/migrateDaos.ts"
+v06-sponsor-proposal = "yarn run tsx scripts/v0.6/sponsorProposal.ts"
 v07-collect-meteora-damm-fees = "yarn run tsx scripts/v0.7/collectMeteoraDammFees.ts"
 v07-launch-template = "yarn run tsx scripts/v0.7/launchTemplate.ts"
 v07-start-launch = "yarn run tsx scripts/v0.7/startLaunch.ts"

--- a/scripts/v0.6/sponsorProposal.ts
+++ b/scripts/v0.6/sponsorProposal.ts
@@ -1,0 +1,61 @@
+import * as anchor from "@coral-xyz/anchor";
+import { FutarchyClient } from "@metadaoproject/programs/futarchy/v0.6";
+import { PublicKey, TransactionMessage } from "@solana/web3.js";
+import bs58 from "bs58";
+
+// Set the DAO and the proposal its team wants to sponsor before running the script
+const DAO = new PublicKey("");
+const PROPOSAL = new PublicKey("");
+
+const provider = anchor.AnchorProvider.env();
+const futarchyClient = FutarchyClient.createClient({ provider });
+
+const sponsorProposal = async () => {
+  const dao = await futarchyClient.fetchDao(DAO);
+
+  if (!dao) {
+    throw new Error("DAO not found");
+  }
+
+  const proposal = await futarchyClient.fetchProposal(PROPOSAL);
+
+  if (!proposal) {
+    throw new Error("Proposal not found");
+  }
+
+  if (!proposal.dao.equals(DAO)) {
+    throw new Error(
+      `Proposal belongs to DAO ${proposal.dao.toBase58()}, not ${DAO.toBase58()}`,
+    );
+  }
+
+  console.log(`Proposal: ${PROPOSAL.toBase58()}`);
+  console.log(`DAO: ${DAO.toBase58()}`);
+  console.log(`Team address: ${dao.teamAddress.toBase58()}`);
+
+  const sponsorIx = await futarchyClient
+    .sponsorProposalIx({
+      proposal: PROPOSAL,
+      dao: DAO,
+      teamAddress: dao.teamAddress,
+    })
+    .instruction();
+
+  const transactionMessage = new TransactionMessage({
+    instructions: [sponsorIx],
+    payerKey: dao.teamAddress,
+    recentBlockhash: (await provider.connection.getLatestBlockhash()).blockhash,
+  });
+
+  const serializedMessage = transactionMessage
+    .compileToLegacyMessage()
+    .serialize();
+
+  console.log("\nTransaction message (base58):");
+  console.log(bs58.encode(serializedMessage));
+
+  console.log("\nTransaction message (base64):");
+  console.log(serializedMessage.toString("base64"));
+};
+
+sponsorProposal().catch(console.error);


### PR DESCRIPTION
Title

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds an Anchor command that prepares a v0.6 team-sponsorship instruction for import into Squads.
- Validates that the proposal belongs to the selected DAO.
- Uses the DAO team address as the required signer and fee payer.
- Prints the serialized transaction message in base58 and base64.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no concrete blocking or independently actionable non-blocking issues identified.

The command follows established operator-script conventions, validates the DAO/proposal relationship, and intentionally emits an unsigned message for the external Squads signing workflow.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| Anchor.toml | Registers the new sponsorship script under the v0.6 Anchor commands. |
| scripts/v0.6/sponsorProposal.ts | Builds and exports a validated team-sponsorship transaction message for the external Squads signing workflow. |

</details>

<sub>Reviews (1): Last reviewed commit: ["team sponsor via squads script"](https://github.com/metadaoproject/programs/commit/f4283855710f792e131a39a0347d881ae714b575) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53233118)</sub>

<!-- /greptile_comment -->