### PR TITLE
move SDK into symlink, drop force from installation path

### DIFF
--- a/.github/workflows/repo-guard.yml
+++ b/.github/workflows/repo-guard.yml
@@ -40,17 +40,19 @@ jobs:
           node-version: '20.18.0'
           cache: 'yarn'
 
-      - name: Verify root yarn.lock is up to date
-        id: yarn_root
-        continue-on-error: true
-        run: yarn install --frozen-lockfile --ignore-scripts --non-interactive
-
+      # sdk first: the root install links `link:./sdk` and needs sdk/node_modules to exist.
       - name: Verify sdk yarn.lock is up to date
         id: yarn_sdk
         continue-on-error: true
         run: |
           cd sdk
           yarn install --frozen-lockfile --ignore-scripts --non-interactive
+
+      - name: Verify root yarn.lock is up to date
+        id: yarn_root
+        continue-on-error: true
+        if: steps.yarn_sdk.outcome == 'success'
+        run: yarn install --frozen-lockfile --ignore-scripts --non-interactive
 
       - name: Run repository guard checks
         id: guard
@@ -83,24 +85,26 @@ jobs:
               echo "  - Out of sync with the workspace manifests. Run \`cargo update --workspace\` (or rebuild) and commit the updated \`Cargo.lock\`."
             fi
 
-            if [ "$YARN_ROOT_OUTCOME" = "success" ]; then
-              echo "- yarn.lock (root): pass"
-            else
-              echo "- yarn.lock (root): fail"
-              echo "  - Root \`yarn.lock\` is out of date. Run \`yarn install\` at the repo root and commit the result."
-            fi
-
             if [ "$YARN_SDK_OUTCOME" = "success" ]; then
               echo "- yarn.lock (sdk): pass"
             else
               echo "- yarn.lock (sdk): fail"
-              echo "  - \`sdk/yarn.lock\` is out of date. Run \`yarn install\` in \`sdk/\` and commit the result."
+              echo "  - \`yarn install --frozen-lockfile\` failed in \`sdk/\`. Usually \`sdk/yarn.lock\` is out of date: run \`yarn install\` in \`sdk/\` and commit the result. See the step log for the actual error."
+            fi
+
+            if [ "$YARN_ROOT_OUTCOME" = "success" ]; then
+              echo "- yarn.lock (root): pass"
+            elif [ "$YARN_ROOT_OUTCOME" = "skipped" ]; then
+              echo "- yarn.lock (root): skipped (sdk install failed - fix that first)"
+            else
+              echo "- yarn.lock (root): fail"
+              echo "  - \`yarn install --frozen-lockfile\` failed at the repo root. Usually the root \`yarn.lock\` is out of date: run \`yarn install\` at the repo root and commit the result. See the step log for the actual error."
             fi
 
             if [ "$GUARD_OUTCOME" = "success" ]; then
               echo "- Repo guard: pass"
             elif [ "$GUARD_OUTCOME" = "skipped" ]; then
-              echo "- Repo guard: skipped (root yarn install failed - fix that first)"
+              echo "- Repo guard: skipped (yarn install failed - fix that first)"
             else
               if [ "$EMERGENCY_BYPASS" = "true" ]; then
                 echo "- Repo guard: bypassed with \`emergency-override\`"
@@ -161,11 +165,13 @@ jobs:
           if [ "$CARGO_OUTCOME" != "success" ]; then
             failed+=("Cargo.lock out of sync - run \`cargo update --workspace\` (or rebuild) and commit")
           fi
-          if [ "$YARN_ROOT_OUTCOME" != "success" ]; then
-            failed+=("root yarn.lock out of date - run \`yarn install\` at repo root and commit")
-          fi
           if [ "$YARN_SDK_OUTCOME" != "success" ]; then
-            failed+=("sdk yarn.lock out of date - run \`yarn install\` in \`sdk/\` and commit")
+            failed+=("sdk yarn install failed - usually \`sdk/yarn.lock\` is out of date: run \`yarn install\` in \`sdk/\` and commit")
+          fi
+          if [ "$YARN_ROOT_OUTCOME" = "skipped" ]; then
+            failed+=("root yarn.lock check skipped - fix the sdk install first")
+          elif [ "$YARN_ROOT_OUTCOME" != "success" ]; then
+            failed+=("root yarn install failed - usually root \`yarn.lock\` is out of date: run \`yarn install\` at repo root and commit")
           fi
 
           # The guard itself (exact-version, age, action-pinning, toolchain

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -298,7 +298,7 @@ External programs required for tests. These are pre-compiled `.so` files in `tes
 
 **"blockstore error"**: `rm -rf .anchor/test-ledger test-ledger`
 
-**Module resolution errors**: `cd sdk && yarn build-local && cd .. && yarn install --force`
+**Module resolution errors**: `cd sdk && yarn build-local` (the root `node_modules` entry is a symlink to `sdk/`, so no root reinstall is needed)
 
 **Tests timeout**: Increase `startup_wait` in `Anchor.toml`
 

--- a/README.md
+++ b/README.md
@@ -125,38 +125,23 @@ Reload your shell configuration:
 source ~/.zshrc  # or source ~/.bash_profile
 ```
 
-#### 7. Install Dependencies
+#### 7. Build Programs and Install Dependencies
 
-Install root project dependencies:
-
-```bash
-yarn install
-```
-
-Install SDK dependencies and build:
+Build all programs, install and build the SDK, install the root dependencies, and lint in one step:
 
 ```bash
-cd sdk
-yarn install
-yarn build-local
-cd ..
+./rebuild.sh
 ```
 
-#### 8. Build Programs
+Re-run `./rebuild.sh` after changing program or SDK code so tests run against your latest changes.
 
-Build all Solana programs:
+To build a single program on its own:
 
 ```bash
-anchor build
+anchor build -p futarchy
 ```
 
-Or build a specific program:
-
-```bash
-anchor build -p programs
-```
-
-#### 9. Run Tests
+#### 8. Run Tests
 
 Run all tests:
 
@@ -184,13 +169,12 @@ Then run `anchor test` again.
 
 #### "Cannot find module" errors
 
-If you see module resolution errors, rebuild the SDK:
+If you see module resolution errors, rebuild the SDK. The root `node_modules` entry for `@metadaoproject/programs` is a symlink to `sdk/`, so no root reinstall is needed:
 
 ```bash
 cd sdk
 yarn build-local
 cd ..
-yarn install --force
 ```
 
 #### Tests timeout or validator doesn't start

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@inquirer/prompts": "7.9.0",
     "@ledgerhq/hw-app-solana": "7.10.4",
     "@ledgerhq/hw-transport-node-hid": "6.33.4",
-    "@metadaoproject/programs": "./sdk",
+    "@metadaoproject/programs": "link:./sdk",
     "@metaplex-foundation/mpl-token-metadata": "3.4.0",
     "@metaplex-foundation/umi": "0.9.2",
     "@metaplex-foundation/umi-bundle-defaults": "0.9.2",

--- a/rebuild.sh
+++ b/rebuild.sh
@@ -6,6 +6,6 @@ cd sdk
 yarn install
 yarn build-local
 cd ..
-yarn install --force
+yarn install
 yarn lint:fix
 echo "✅ rebuild complete"

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -4,22 +4,13 @@ A collection of scripts to interact with various parts of the futarchy protocol
 
 ## Setup
 
-It's best to use these scripts with the latest build of the SDK.
-
-To do this, run the following commands, starting in the root dir of the repository:
+The scripts import `@metadaoproject/programs` from the root `node_modules`, where it is a symlink to `sdk/`, so they always run against your local SDK build. No linking is needed. From the root of the repository:
 
 ```sh
-cd sdk # Move into the repository dir
-
-yarn
-yarn build
-yarn link
-
-cd .. # Move back into the root dir
-yarn link @metadaoproject/futarchy # Link to your local build of the futarchy sdk
+./rebuild.sh
 ```
 
-Afterwards, you can run the scripts as you see fit.
+This builds the programs, installs and builds the SDK, and installs the root dependencies. See [Development Setup](../README.md#development-setup) in the main README for toolchain prerequisites. If the programs are already built and you only changed SDK code, `cd sdk && yarn build-local` is enough.
 
 ## Launchpad
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -933,15 +933,9 @@
   resolved "https://registry.yarnpkg.com/@ledgerhq/logs/-/logs-6.17.0.tgz#370840b915a0b44fc867fc4e6afc68d26a2055dd"
   integrity sha512-yra33g5q/AU7+PwAws+GaVpQGUuxnDREjVBnviJjcaJLVKuLzI4pnj8Bd3nY3fypM5k1yZEYKEXfUuGFUjP2+w==
 
-"@metadaoproject/programs@./sdk":
-  version "0.1.1-alpha.0"
-  dependencies:
-    "@coral-xyz/anchor" "0.29.0"
-    "@noble/hashes" "1.8.0"
-    "@solana/spl-token" "0.3.11"
-    "@solana/web3.js" "1.98.4"
-    "@sqds/multisig" "2.1.4"
-    bn.js "5.2.2"
+"@metadaoproject/programs@link:./sdk":
+  version "0.0.0"
+  uid ""
 
 "@metaplex-foundation/beet-solana@0.4.0":
   version "0.4.0"


### PR DESCRIPTION
Tests currently import `@metadaoproject/programs` from a copy of `sdk/` that yarn makes at install time.
The CI action caches `node_modules` under a constant key, and when the root lockfile is unchanged yarn reports `Already up-to-date` and keeps the stale copy, so SDK changes are invisible to CI until the cache is cleared/evicted.
Switching the dependency to `link:./sdk` makes the entry a symlink, so tests always see the current `sdk/dist`, which CI and `rebuild.sh` already rebuild on every run. Drops the `yarn install --force` workaround from `rebuild.sh` and the docs.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR changes the root SDK dependency from a copied local package to a Yarn-managed symlink so consumers see the current SDK build, removes the forced root reinstall, and updates development documentation accordingly.
- Uses `link:./sdk` for `@metadaoproject/programs`.
- Regenerates the Yarn lock entry for the linked package.
- Keeps SDK dependency installation and compilation in `rebuild.sh`.
- Replaces manual setup and linking instructions with the consolidated rebuild workflow.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge; the linked SDK is built and supplied with its own dependencies by the supported setup and CI workflows.

No actionable failure remains: the lockfile matches Yarn 1 semantics, SDK dependencies are installed within `sdk`, and `build-local` generates the distribution files consumed through the symlink.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| package.json | Switches the local SDK dependency to Yarn's symlink-based `link:` protocol. |
| yarn.lock | Records the expected Yarn 1 lockfile representation for the linked SDK. |
| rebuild.sh | Retains ordered program and SDK builds while replacing the forced root install with a normal install. |
| README.md | Consolidates development setup around `rebuild.sh` and documents symlink-based SDK resolution. |
| scripts/README.md | Removes manual Yarn linking and directs script users to the repository rebuild workflow. |

</details>

<sub>Reviews (1): Last reviewed commit: ["move SDK into symlink, drop force from i..."](https://github.com/metadaoproject/programs/commit/c0bdf963ef9a6979ba4e2ca2df20779a22bc1f75) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60044124)</sub>

**Context used:**

- Knowledge Base — [TypeScript SDK](https://app.greptile.com/metadao/-/custom-context/knowledge-base/metadaoproject/programs/-/docs/typescript-sdk.md)
- Knowledge Base — [Roll back yarn.lock changes that broke CI](https://app.greptile.com/metadao/-/custom-context/knowledge-base/metadaoproject/programs/-/reverts/incident-mitigation_242-20240814-ci-yarn-lock-rollback-e49fdab.md)

<!-- /greptile_comment -->