### PR TITLE
fix(sdk): use squads vault as payerKey in squadsProposalCreateTx

### DIFF
--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metadaoproject/programs",
-  "version": "0.1.1-alpha.0",
+  "version": "0.1.1-alpha.1",
   "type": "module",
   "main": "dist/index.js",
   "module": "dist/index.js",

--- a/sdk/src/futarchy/v0.6/FutarchyClient.ts
+++ b/sdk/src/futarchy/v0.6/FutarchyClient.ts
@@ -592,9 +592,14 @@ export class FutarchyClient {
     payer?: PublicKey;
   }): { tx: Transaction; squadsProposal: PublicKey } {
     const multisigPda = multisig.getMultisigPda({ createKey: dao })[0];
+    const squadsMultisigVault = multisig.getVaultPda({
+      multisigPda,
+      index: 0,
+    })[0];
 
+    // The vault must be the payerKey, otherwise the payer has to co-sign every execution.
     const transactionMessage = new TransactionMessage({
-      payerKey: payer,
+      payerKey: squadsMultisigVault,
       recentBlockhash: "", // this doesn't get used
       instructions,
     });


### PR DESCRIPTION
Title.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates Squads proposal transaction construction so the DAO’s index-zero multisig vault is the stored transaction-message payer, while retaining the caller-provided payer for proposal account rent. It also increments the SDK prerelease version.

- Derives the Squads vault from the DAO multisig.
- Uses that vault as the inner transaction-message payer.
- Preserves caller-managed funding and signing for the outer creation transaction.
- Bumps the SDK package to `0.1.1-alpha.1`.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge; the payer change aligns with established Squads vault-transaction construction patterns and no actionable regression was identified.

The derived vault matches the transaction’s existing vault index, while the caller-provided payer continues funding account creation and the outer transaction, so proposal creation and later execution retain their intended signer responsibilities.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| sdk/src/futarchy/v0.6/FutarchyClient.ts | Changes the stored Squads transaction-message payer to the matching index-zero multisig vault while preserving the external rent payer. |
| sdk/package.json | Advances the SDK prerelease package version from `0.1.1-alpha.0` to `0.1.1-alpha.1`. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(sdk): use squads vault as payerKey i..."](https://github.com/metadaoproject/programs/commit/b8e063d39947c0a528e58ed52970810cd6c45dff) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=62259651)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [Client and exchange integrations](https://app.greptile.com/metadao/-/custom-context/knowledge-base/metadaoproject/programs/-/docs/client-integrations.md)
- Knowledge Base — [TypeScript SDK](https://app.greptile.com/metadao/-/custom-context/knowledge-base/metadaoproject/programs/-/docs/typescript-sdk.md)
- Knowledge Base — [Futarchy governance program](https://app.greptile.com/metadao/-/custom-context/knowledge-base/metadaoproject/programs/-/docs/futarchy-governance.md)
</details>


<!-- /greptile_comment -->